### PR TITLE
feat: add AFML Ch.13 synthetic backtesting module

### DIFF
--- a/crates/openquant/src/lib.rs
+++ b/crates/openquant/src/lib.rs
@@ -25,4 +25,5 @@ pub mod sample_weights;
 pub mod sampling;
 pub mod sb_bagging;
 pub mod structural_breaks;
+pub mod synthetic_backtesting;
 pub mod util;

--- a/crates/openquant/src/synthetic_backtesting.rs
+++ b/crates/openquant/src/synthetic_backtesting.rs
@@ -1,0 +1,400 @@
+//! Synthetic-data backtesting utilities aligned to AFML Chapter 13.
+//!
+//! This module focuses on optimal trading-rule (OTR) search over profit-taking
+//! and stop-loss corridors by:
+//! 1) calibrating an AR(1)/discrete O-U process from historical prices,
+//! 2) generating many synthetic paths under that calibrated process,
+//! 3) evaluating a PT/SL mesh on those paths, and
+//! 4) detecting when the response surface lacks a stable optimum.
+
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use rand_distr::{Distribution, StandardNormal};
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct OuProcessParams {
+    pub phi: f64,
+    pub intercept: f64,
+    pub equilibrium: f64,
+    pub sigma: f64,
+    pub r_squared: f64,
+    pub stationary: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TradingRule {
+    pub profit_taking: f64,
+    pub stop_loss: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RuleSurfacePoint {
+    pub rule: TradingRule,
+    pub sharpe: f64,
+    pub mean_return: f64,
+    pub std_return: f64,
+    pub win_rate: f64,
+    pub avg_holding_steps: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct StabilityCriteria {
+    pub random_walk_phi_threshold: f64,
+    pub min_peak_margin: f64,
+    pub min_surface_std: f64,
+    pub min_best_sharpe: f64,
+}
+
+impl Default for StabilityCriteria {
+    fn default() -> Self {
+        Self {
+            random_walk_phi_threshold: 0.97,
+            min_peak_margin: 0.20,
+            min_surface_std: 0.10,
+            min_best_sharpe: 0.30,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct StabilityDiagnostics {
+    pub no_stable_optimum: bool,
+    pub reason: String,
+    pub best_sharpe: f64,
+    pub median_sharpe: f64,
+    pub peak_margin: f64,
+    pub surface_std: f64,
+    pub estimated_phi: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct OtrSearchResult {
+    pub params: OuProcessParams,
+    pub best_rule: TradingRule,
+    pub best_point: RuleSurfacePoint,
+    pub response_surface: Vec<RuleSurfacePoint>,
+    pub diagnostics: StabilityDiagnostics,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SyntheticBacktestConfig {
+    pub initial_price: f64,
+    pub n_paths: usize,
+    pub horizon: usize,
+    pub seed: u64,
+    pub profit_taking_grid: Vec<f64>,
+    pub stop_loss_grid: Vec<f64>,
+    pub max_holding_steps: usize,
+    pub annualization_factor: f64,
+    pub stability_criteria: StabilityCriteria,
+}
+
+pub fn calibrate_ou_params(prices: &[f64]) -> Result<OuProcessParams, String> {
+    if prices.len() < 3 {
+        return Err("prices must include at least 3 observations".to_string());
+    }
+    if prices.iter().any(|p| !p.is_finite()) {
+        return Err("prices must be finite".to_string());
+    }
+
+    let n = prices.len() - 1;
+    let x = &prices[..n];
+    let y = &prices[1..];
+
+    let mean_x = x.iter().sum::<f64>() / n as f64;
+    let mean_y = y.iter().sum::<f64>() / n as f64;
+
+    let mut var_x = 0.0;
+    let mut cov_xy = 0.0;
+    for i in 0..n {
+        let dx = x[i] - mean_x;
+        var_x += dx * dx;
+        cov_xy += dx * (y[i] - mean_y);
+    }
+    if var_x <= 0.0 {
+        return Err("cannot calibrate O-U from constant price series".to_string());
+    }
+
+    let phi = cov_xy / var_x;
+    let intercept = mean_y - phi * mean_x;
+    let denom = 1.0 - phi;
+    let equilibrium = if denom.abs() > 1e-12 { intercept / denom } else { mean_y };
+
+    let mut residuals = Vec::with_capacity(n);
+    for i in 0..n {
+        let fitted = intercept + phi * x[i];
+        residuals.push(y[i] - fitted);
+    }
+
+    let sigma = std_dev(&residuals);
+    if !sigma.is_finite() || sigma <= 0.0 {
+        return Err("estimated innovation sigma must be positive".to_string());
+    }
+
+    let ss_res = residuals.iter().map(|e| e * e).sum::<f64>();
+    let ss_tot = y
+        .iter()
+        .map(|v| {
+            let d = *v - mean_y;
+            d * d
+        })
+        .sum::<f64>();
+    let r_squared = if ss_tot > 0.0 { (1.0 - ss_res / ss_tot).clamp(-1.0, 1.0) } else { 0.0 };
+
+    Ok(OuProcessParams {
+        phi,
+        intercept,
+        equilibrium,
+        sigma,
+        r_squared,
+        stationary: phi.abs() < 1.0,
+    })
+}
+
+pub fn generate_ou_paths(
+    params: OuProcessParams,
+    initial_price: f64,
+    n_paths: usize,
+    horizon: usize,
+    seed: u64,
+) -> Result<Vec<Vec<f64>>, String> {
+    if !initial_price.is_finite() {
+        return Err("initial_price must be finite".to_string());
+    }
+    if n_paths == 0 || horizon < 2 {
+        return Err("n_paths must be > 0 and horizon must be >= 2".to_string());
+    }
+    if !params.phi.is_finite()
+        || !params.intercept.is_finite()
+        || !params.equilibrium.is_finite()
+        || !params.sigma.is_finite()
+    {
+        return Err("O-U parameters must be finite".to_string());
+    }
+    if params.sigma < 0.0 {
+        return Err("sigma must be non-negative".to_string());
+    }
+
+    let mut rng = StdRng::seed_from_u64(seed);
+    let noise = StandardNormal;
+    let mut out = Vec::with_capacity(n_paths);
+
+    for _ in 0..n_paths {
+        let mut path = Vec::with_capacity(horizon);
+        path.push(initial_price);
+        for _ in 1..horizon {
+            let prev = path[path.len() - 1];
+            let eps: f64 = noise.sample(&mut rng);
+            let next = params.intercept + params.phi * prev + params.sigma * eps;
+            path.push(next);
+        }
+        out.push(path);
+    }
+
+    Ok(out)
+}
+
+pub fn evaluate_rule_on_paths(
+    paths: &[Vec<f64>],
+    rule: TradingRule,
+    max_holding_steps: usize,
+    annualization_factor: f64,
+) -> Result<RuleSurfacePoint, String> {
+    if paths.is_empty() {
+        return Err("paths cannot be empty".to_string());
+    }
+    if rule.profit_taking <= 0.0 || rule.stop_loss <= 0.0 {
+        return Err("profit_taking and stop_loss must be > 0".to_string());
+    }
+    if max_holding_steps == 0 {
+        return Err("max_holding_steps must be > 0".to_string());
+    }
+    if annualization_factor <= 0.0 || !annualization_factor.is_finite() {
+        return Err("annualization_factor must be finite and > 0".to_string());
+    }
+
+    let mut terminal_returns = Vec::with_capacity(paths.len());
+    let mut holding_steps = Vec::with_capacity(paths.len());
+
+    for path in paths {
+        if path.len() < 2 {
+            return Err("every path must have at least 2 points".to_string());
+        }
+        if path.iter().any(|p| !p.is_finite()) {
+            return Err("paths must contain only finite values".to_string());
+        }
+
+        let entry = path[0];
+        let max_step = max_holding_steps.min(path.len() - 1);
+
+        let mut exited = false;
+        let mut ret = path[max_step] - entry;
+        let mut hold = max_step;
+
+        for (step, px) in path.iter().enumerate().take(max_step + 1).skip(1) {
+            let pnl = *px - entry;
+            if pnl >= rule.profit_taking || pnl <= -rule.stop_loss {
+                exited = true;
+                ret = pnl;
+                hold = step;
+                break;
+            }
+        }
+
+        if !exited {
+            hold = max_step;
+        }
+        terminal_returns.push(ret);
+        holding_steps.push(hold as f64);
+    }
+
+    let mean_return = terminal_returns.iter().sum::<f64>() / terminal_returns.len() as f64;
+    let std_return = std_dev(&terminal_returns);
+    let sharpe =
+        if std_return > 0.0 { mean_return / std_return * annualization_factor.sqrt() } else { 0.0 };
+    let wins = terminal_returns.iter().filter(|r| **r > 0.0).count() as f64;
+    let win_rate = wins / terminal_returns.len() as f64;
+    let avg_holding_steps = holding_steps.iter().sum::<f64>() / holding_steps.len() as f64;
+
+    Ok(RuleSurfacePoint { rule, sharpe, mean_return, std_return, win_rate, avg_holding_steps })
+}
+
+pub fn detect_no_stable_optimum(
+    response_surface: &[RuleSurfacePoint],
+    estimated_phi: f64,
+    criteria: StabilityCriteria,
+) -> Result<StabilityDiagnostics, String> {
+    if response_surface.is_empty() {
+        return Err("response_surface cannot be empty".to_string());
+    }
+
+    let mut sharpes = response_surface.iter().map(|p| p.sharpe).collect::<Vec<_>>();
+    sharpes.sort_by(|a, b| a.total_cmp(b));
+
+    let best_sharpe = *sharpes.last().ok_or_else(|| "no sharpe values".to_string())?;
+    let median_sharpe = median_sorted(&sharpes);
+    let peak_margin = best_sharpe - median_sharpe;
+    let surface_std = std_dev(&sharpes);
+
+    let near_random_walk = estimated_phi.abs() >= criteria.random_walk_phi_threshold;
+    let weak_peak = peak_margin < criteria.min_peak_margin;
+    let flat_surface = surface_std < criteria.min_surface_std;
+    let weak_best = best_sharpe < criteria.min_best_sharpe;
+    let no_stable_optimum =
+        (near_random_walk && (weak_peak || flat_surface)) || (weak_best && weak_peak);
+
+    let reason = if no_stable_optimum {
+        if near_random_walk {
+            "no stable optimum: estimated process is near random-walk and the PT/SL surface is weakly structured"
+                .to_string()
+        } else {
+            "no stable optimum: best rule has weak edge relative to the response surface"
+                .to_string()
+        }
+    } else {
+        "stable optimum detected".to_string()
+    };
+
+    Ok(StabilityDiagnostics {
+        no_stable_optimum,
+        reason,
+        best_sharpe,
+        median_sharpe,
+        peak_margin,
+        surface_std,
+        estimated_phi,
+    })
+}
+
+pub fn search_optimal_trading_rule(
+    params: OuProcessParams,
+    paths: &[Vec<f64>],
+    profit_taking_grid: &[f64],
+    stop_loss_grid: &[f64],
+    max_holding_steps: usize,
+    annualization_factor: f64,
+    stability_criteria: StabilityCriteria,
+) -> Result<OtrSearchResult, String> {
+    if profit_taking_grid.is_empty() || stop_loss_grid.is_empty() {
+        return Err("profit_taking_grid and stop_loss_grid must be non-empty".to_string());
+    }
+
+    let mut response_surface = Vec::with_capacity(profit_taking_grid.len() * stop_loss_grid.len());
+    for &pt in profit_taking_grid {
+        for &sl in stop_loss_grid {
+            let point = evaluate_rule_on_paths(
+                paths,
+                TradingRule { profit_taking: pt, stop_loss: sl },
+                max_holding_steps,
+                annualization_factor,
+            )?;
+            response_surface.push(point);
+        }
+    }
+
+    response_surface.sort_by(|a, b| {
+        b.sharpe.total_cmp(&a.sharpe).then_with(|| b.mean_return.total_cmp(&a.mean_return))
+    });
+
+    let best_point =
+        response_surface.first().cloned().ok_or_else(|| "response surface is empty".to_string())?;
+    let best_rule = best_point.rule;
+    let diagnostics = detect_no_stable_optimum(&response_surface, params.phi, stability_criteria)?;
+
+    Ok(OtrSearchResult { params, best_rule, best_point, response_surface, diagnostics })
+}
+
+pub fn run_synthetic_otr_workflow(
+    historical_prices: &[f64],
+    config: &SyntheticBacktestConfig,
+) -> Result<OtrSearchResult, String> {
+    if config.profit_taking_grid.iter().any(|v| *v <= 0.0 || !v.is_finite()) {
+        return Err("profit_taking_grid values must be finite and > 0".to_string());
+    }
+    if config.stop_loss_grid.iter().any(|v| *v <= 0.0 || !v.is_finite()) {
+        return Err("stop_loss_grid values must be finite and > 0".to_string());
+    }
+
+    let params = calibrate_ou_params(historical_prices)?;
+    let paths = generate_ou_paths(
+        params,
+        config.initial_price,
+        config.n_paths,
+        config.horizon,
+        config.seed,
+    )?;
+    search_optimal_trading_rule(
+        params,
+        &paths,
+        &config.profit_taking_grid,
+        &config.stop_loss_grid,
+        config.max_holding_steps,
+        config.annualization_factor,
+        config.stability_criteria,
+    )
+}
+
+fn std_dev(values: &[f64]) -> f64 {
+    if values.len() < 2 {
+        return 0.0;
+    }
+    let mean = values.iter().sum::<f64>() / values.len() as f64;
+    let mut ss = 0.0;
+    for v in values {
+        let d = *v - mean;
+        ss += d * d;
+    }
+    (ss / (values.len() as f64 - 1.0)).sqrt()
+}
+
+fn median_sorted(sorted: &[f64]) -> f64 {
+    let n = sorted.len();
+    if n == 0 {
+        return 0.0;
+    }
+    if n % 2 == 1 {
+        sorted[n / 2]
+    } else {
+        0.5 * (sorted[n / 2 - 1] + sorted[n / 2])
+    }
+}

--- a/crates/openquant/tests/synthetic_backtesting.rs
+++ b/crates/openquant/tests/synthetic_backtesting.rs
@@ -1,0 +1,157 @@
+use openquant::synthetic_backtesting::{
+    calibrate_ou_params, detect_no_stable_optimum, generate_ou_paths, run_synthetic_otr_workflow,
+    search_optimal_trading_rule, OuProcessParams, RuleSurfacePoint, StabilityCriteria,
+    SyntheticBacktestConfig, TradingRule,
+};
+
+#[test]
+fn test_generate_ou_paths_is_seeded_and_reproducible() {
+    let params = OuProcessParams {
+        phi: 0.85,
+        intercept: 15.0,
+        equilibrium: 100.0,
+        sigma: 1.25,
+        r_squared: 0.9,
+        stationary: true,
+    };
+
+    let p1 = generate_ou_paths(params, 98.0, 16, 64, 42).unwrap();
+    let p2 = generate_ou_paths(params, 98.0, 16, 64, 42).unwrap();
+    let p3 = generate_ou_paths(params, 98.0, 16, 64, 43).unwrap();
+
+    assert_eq!(p1, p2);
+    assert_ne!(p1, p3);
+}
+
+#[test]
+fn test_calibration_recovers_ou_phi_reasonably() {
+    let true_params = OuProcessParams {
+        phi: 0.82,
+        intercept: 18.0,
+        equilibrium: 100.0,
+        sigma: 0.8,
+        r_squared: 0.0,
+        stationary: true,
+    };
+    let paths = generate_ou_paths(true_params, 100.0, 1, 1200, 7).unwrap();
+    let fit = calibrate_ou_params(&paths[0]).unwrap();
+
+    assert!((fit.phi - true_params.phi).abs() < 0.08);
+    assert!(fit.sigma > 0.0);
+    assert!(fit.stationary);
+}
+
+#[test]
+fn test_regime_contrast_mean_reverting_vs_random_walk_like() {
+    let mean_reverting = OuProcessParams {
+        phi: 0.65,
+        intercept: 0.35,
+        equilibrium: 1.0,
+        sigma: 1.0,
+        r_squared: 0.0,
+        stationary: true,
+    };
+    let random_walk_like = OuProcessParams {
+        phi: 0.995,
+        intercept: 0.0,
+        equilibrium: 0.0,
+        sigma: 1.0,
+        r_squared: 0.0,
+        stationary: true,
+    };
+
+    let pt_grid = vec![0.5, 1.0, 1.5, 2.0, 3.0, 4.0];
+    let sl_grid = vec![0.5, 1.0, 2.0, 3.0, 4.0];
+    let criteria = StabilityCriteria::default();
+
+    let mr_paths = generate_ou_paths(mean_reverting, 0.0, 4_000, 128, 11).unwrap();
+    let rw_paths = generate_ou_paths(random_walk_like, 0.0, 4_000, 128, 11).unwrap();
+
+    let mr = search_optimal_trading_rule(
+        mean_reverting,
+        &mr_paths,
+        &pt_grid,
+        &sl_grid,
+        64,
+        1.0,
+        criteria,
+    )
+    .unwrap();
+    let rw = search_optimal_trading_rule(
+        random_walk_like,
+        &rw_paths,
+        &pt_grid,
+        &sl_grid,
+        64,
+        1.0,
+        criteria,
+    )
+    .unwrap();
+
+    assert!(mr.best_point.sharpe > rw.best_point.sharpe + 0.1);
+    assert!(!mr.diagnostics.no_stable_optimum);
+    assert!(rw.diagnostics.no_stable_optimum);
+}
+
+#[test]
+fn test_detect_no_stable_optimum_for_flat_surface() {
+    let flat = vec![
+        RuleSurfacePoint {
+            rule: TradingRule { profit_taking: 1.0, stop_loss: 1.0 },
+            sharpe: 0.04,
+            mean_return: 0.01,
+            std_return: 0.25,
+            win_rate: 0.50,
+            avg_holding_steps: 10.0,
+        },
+        RuleSurfacePoint {
+            rule: TradingRule { profit_taking: 1.0, stop_loss: 2.0 },
+            sharpe: 0.05,
+            mean_return: 0.01,
+            std_return: 0.25,
+            win_rate: 0.50,
+            avg_holding_steps: 10.0,
+        },
+        RuleSurfacePoint {
+            rule: TradingRule { profit_taking: 2.0, stop_loss: 1.0 },
+            sharpe: 0.03,
+            mean_return: 0.01,
+            std_return: 0.25,
+            win_rate: 0.50,
+            avg_holding_steps: 10.0,
+        },
+    ];
+
+    let diag = detect_no_stable_optimum(&flat, 0.99, StabilityCriteria::default()).unwrap();
+    assert!(diag.no_stable_optimum);
+    assert!(diag.reason.contains("no stable optimum"));
+}
+
+#[test]
+fn test_run_synthetic_otr_workflow_end_to_end() {
+    let params = OuProcessParams {
+        phi: 0.75,
+        intercept: 0.5,
+        equilibrium: 2.0,
+        sigma: 1.0,
+        r_squared: 0.0,
+        stationary: true,
+    };
+    let historical = generate_ou_paths(params, 0.0, 1, 800, 9).unwrap();
+    let config = SyntheticBacktestConfig {
+        initial_price: 0.0,
+        n_paths: 1500,
+        horizon: 96,
+        seed: 77,
+        profit_taking_grid: vec![0.5, 1.0, 2.0, 3.0],
+        stop_loss_grid: vec![0.5, 1.0, 2.0, 3.0],
+        max_holding_steps: 64,
+        annualization_factor: 1.0,
+        stability_criteria: StabilityCriteria::default(),
+    };
+
+    let result = run_synthetic_otr_workflow(&historical[0], &config).unwrap();
+    assert_eq!(result.response_surface.len(), 16);
+    assert!(result.best_point.sharpe.is_finite());
+    assert!(result.params.sigma > 0.0);
+}

--- a/docs-site/src/data/afmlDocsState.ts
+++ b/docs-site/src/data/afmlDocsState.ts
@@ -199,6 +199,20 @@ export const afmlDocsState = {
       ]
     },
     {
+      "chapter": "CHAPTER 13",
+      "theme": "Synthetic backtesting and OTR",
+      "status": "done",
+      "chunkCount": 25,
+      "sections": [
+        {
+          "id": "chapter-13-synthetic_backtesting",
+          "module": "synthetic_backtesting",
+          "slug": "synthetic-backtesting",
+          "status": "done"
+        }
+      ]
+    },
+    {
       "chapter": "CHAPTER 14",
       "theme": "Backtest diagnostics",
       "status": "done",

--- a/docs-site/src/data/moduleDocs.ts
+++ b/docs-site/src/data/moduleDocs.ts
@@ -707,6 +707,47 @@ export const moduleDocs: ModuleDoc[] = [
     notes: ["Sequential bootstrap improves diversity under event overlap.", "Tune max_samples/max_features with out-of-sample monitoring."],
   },
   {
+    slug: "synthetic-backtesting",
+    module: "synthetic_backtesting",
+    subject: "Sampling, Validation and ML Diagnostics",
+    summary: "Synthetic-data OTR backtesting with O-U calibration, PT/SL mesh search, and stability diagnostics.",
+    whyItExists:
+      "AFML Chapter 13 shows that selecting PT/SL rules on a single historical path is prone to overfitting; synthetic path ensembles let us evaluate rule robustness under calibrated process dynamics.",
+    keyApis: [
+      "calibrate_ou_params",
+      "generate_ou_paths",
+      "evaluate_rule_on_paths",
+      "search_optimal_trading_rule",
+      "detect_no_stable_optimum",
+      "run_synthetic_otr_workflow",
+    ],
+    formulas: [
+      {
+        label: "Discrete O-U (AR(1))",
+        latex: "P_t=\\alpha+\\phi P_{t-1}+\\sigma\\epsilon_t,\\quad \\epsilon_t\\sim\\mathcal N(0,1)",
+      },
+      {
+        label: "Equilibrium Level",
+        latex: "\\bar P=\\frac{\\alpha}{1-\\phi}",
+      },
+      {
+        label: "OTR Objective over Rule Mesh",
+        latex: "R^*=\\arg\\max_{R\\in\\Omega}\\frac{\\mathbb E[\\pi\\mid R]}{\\sigma[\\pi\\mid R]}",
+      },
+    ],
+    examples: [
+      {
+        title: "End-to-end synthetic OTR workflow",
+        language: "rust",
+        code: `use openquant::synthetic_backtesting::{run_synthetic_otr_workflow, StabilityCriteria, SyntheticBacktestConfig};\n\nlet cfg = SyntheticBacktestConfig {\n  initial_price: historical_prices[historical_prices.len() - 1],\n  n_paths: 10_000,\n  horizon: 128,\n  seed: 42,\n  profit_taking_grid: vec![0.5, 1.0, 1.5, 2.0, 3.0],\n  stop_loss_grid: vec![0.5, 1.0, 1.5, 2.0, 3.0],\n  max_holding_steps: 64,\n  annualization_factor: 1.0,\n  stability_criteria: StabilityCriteria::default(),\n};\n\nlet out = run_synthetic_otr_workflow(&historical_prices, &cfg)?;\nif out.diagnostics.no_stable_optimum {\n  println!(\"Skip OTR optimization: {}\", out.diagnostics.reason);\n} else {\n  println!(\"Best PT/SL: {:?}\", out.best_rule);\n}`,
+      },
+    ],
+    notes: [
+      "Near-random-walk estimates (|phi| close to 1) often produce flat Sharpe heatmaps where any selected rule is unstable out-of-sample.",
+      "Calibrating to process parameters and evaluating many synthetic paths reduces single-path lucky-fit risk compared to brute-force historical optimization.",
+    ],
+  },
+  {
     slug: "structural-breaks",
     module: "structural_breaks",
     subject: "Market Microstructure, Dependence and Regime Detection",

--- a/docs-site/src/pages/api-reference.astro
+++ b/docs-site/src/pages/api-reference.astro
@@ -21,6 +21,7 @@ import Layout from "../layouts/Layout.astro";
     <li><code>cross_validation::ml_cross_val_score</code>, <code>cross_validation::ml_get_train_times</code>, <code>cross_validation::PurgedKFold</code></li>
     <li><code>backtesting_engine::run_walk_forward</code>, <code>backtesting_engine::run_cross_validation</code>, <code>backtesting_engine::run_cpcv</code>, <code>backtesting_engine::cpcv_path_count</code></li>
     <li><code>hyperparameter_tuning::grid_search</code>, <code>hyperparameter_tuning::randomized_search</code>, <code>hyperparameter_tuning::sample_log_uniform</code>, <code>hyperparameter_tuning::classification_score</code></li>
+    <li><code>synthetic_backtesting::calibrate_ou_params</code>, <code>synthetic_backtesting::generate_ou_paths</code>, <code>synthetic_backtesting::search_optimal_trading_rule</code>, <code>synthetic_backtesting::detect_no_stable_optimum</code></li>
     <li><code>feature_importance::mean_decrease_impurity</code>, <code>feature_importance::mean_decrease_accuracy</code>, <code>feature_importance::single_feature_importance</code></li>
     <li><code>fingerprint::RegressionModelFingerprint</code>, <code>fingerprint::ClassificationModelFingerprint</code></li>
     <li><code>sb_bagging::SequentiallyBootstrappedBaggingClassifier</code>, <code>sb_bagging::SequentiallyBootstrappedBaggingRegressor</code></li>


### PR DESCRIPTION
Summary:
- add synthetic_backtesting module implementing AFML Ch.13 synthetic OTR workflow
- add O-U calibration, seeded synthetic path generation, PT/SL mesh search, and no-stable-optimum diagnostics
- add integration tests for reproducibility and regime contrast
- wire docs and API references for chapter/module coverage

Validation:
- cargo fmt
- cargo test -p openquant --test synthetic_backtesting
- cargo test -p openquant --lib --tests
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo clippy --all-targets --all-features -- -D clippy::correctness -D clippy::suspicious