### PR TITLE
feat(openquant): add typed error APIs for bet_sizing and filters

### DIFF
--- a/crates/openquant/tests/bet_sizing.rs
+++ b/crates/openquant/tests/bet_sizing.rs
@@ -200,6 +200,18 @@ fn test_confirm_and_cast_to_df_one_series_broadcast() {
 }
 
 #[test]
+fn test_confirm_and_cast_to_df_checked_shape_mismatch_error() {
+    let pos = [25.0, 35.0, 45.0];
+    let max_pos = [55.0, 56.0];
+    let m_p = [75.0];
+    let f = [80.0];
+    let err = confirm_and_cast_to_df_checked(&pos, &max_pos, &m_p, &f)
+        .expect_err("shape mismatch should return typed error");
+    assert_eq!(err, BetSizingError::ShapeMismatch { name: "max_pos", len: 2, expected: 3 });
+    assert!(err.to_string().contains("expected 1 or 3"));
+}
+
+#[test]
 fn test_cdf_mixture_and_single_above_zero() {
     let fit = [0.0, 1.0, 1.0, 2.0, 0.5];
     let cdf = cdf_mixture(fit[0], fit[1], fit[2], fit[3], fit[4], 0.5);

--- a/crates/openquant/tests/ch10_snippets.rs
+++ b/crates/openquant/tests/ch10_snippets.rs
@@ -175,6 +175,16 @@ fn test_bet_size_key_error() {
 }
 
 #[test]
+fn test_bet_size_checked_invalid_function_error() {
+    let err = bet_size_checked(2.0, 0.4, "NotAFunction").expect_err("should return typed error");
+    assert_eq!(
+        err,
+        BetSizingError::InvalidFunction { context: "bet size", func: "NotAFunction".to_string() }
+    );
+    assert!(err.to_string().contains("invalid bet size function"));
+}
+
+#[test]
 fn test_get_target_pos_sigmoid() {
     let f_i: f64 = 34.6;
     let m_p: f64 = 21.9;
@@ -228,6 +238,20 @@ fn test_get_target_pos_key_error() {
 }
 
 #[test]
+fn test_get_target_pos_checked_invalid_function_error() {
+    let err = get_target_pos_checked(1.0, 2.0, 1.0, 5.0, "NotAFunction")
+        .expect_err("should return typed error");
+    assert_eq!(
+        err,
+        BetSizingError::InvalidFunction {
+            context: "get_target_pos",
+            func: "NotAFunction".to_string()
+        }
+    );
+    assert!(err.to_string().contains("invalid get_target_pos function"));
+}
+
+#[test]
 fn test_get_w_sigmoid() {
     let x_sig: f64 = 24.2;
     let m_sig: f64 = 0.98;
@@ -249,6 +273,13 @@ fn test_get_w_power() {
 #[should_panic]
 fn test_get_w_power_value_error() {
     let _ = get_w_power(1.2, 0.8);
+}
+
+#[test]
+fn test_get_w_power_checked_range_error() {
+    let err = get_w_power_checked(1.2, 0.8).expect_err("should return typed error");
+    assert_eq!(err, BetSizingError::PriceDivergenceOutOfRange { value: 1.2 });
+    assert!(err.to_string().contains("price divergence"));
 }
 
 #[test]
@@ -308,6 +339,17 @@ fn test_inv_price_key_error() {
 }
 
 #[test]
+fn test_inv_price_checked_invalid_function_error() {
+    let err =
+        inv_price_checked(12.0, 1.5, 0.7, "NotAFunction").expect_err("should return typed error");
+    assert_eq!(
+        err,
+        BetSizingError::InvalidFunction { context: "inv_price", func: "NotAFunction".to_string() }
+    );
+    assert!(err.to_string().contains("invalid inv_price function"));
+}
+
+#[test]
 fn test_limit_price_sigmoid() {
     let t_pos: f64 = 124.0;
     let pos: f64 = 112.0;
@@ -355,4 +397,18 @@ fn test_limit_price_power() {
 #[should_panic]
 fn test_limit_price_key_error() {
     let _ = limit_price(231.0, 221.0, 110.0, 3.4, 250.0, "NotAFunction");
+}
+
+#[test]
+fn test_limit_price_checked_invalid_function_error() {
+    let err = limit_price_checked(231.0, 221.0, 110.0, 3.4, 250.0, "NotAFunction")
+        .expect_err("should return typed error");
+    assert_eq!(
+        err,
+        BetSizingError::InvalidFunction {
+            context: "limit_price",
+            func: "NotAFunction".to_string()
+        }
+    );
+    assert!(err.to_string().contains("invalid limit_price function"));
 }


### PR DESCRIPTION
## Summary
- add typed error enums and checked APIs in bet sizing and filters modules
- keep existing public APIs as compatibility wrappers
- add tests for invalid function keys, shape mismatch, dynamic threshold/timestamp errors

## Validation
- cargo fmt
- cargo test -p openquant --lib --tests
- cargo clippy --all-targets --all-features -- -D clippy::correctness -D clippy::suspicious