### PR TITLE
Reconcile beads closure history with main deliverables

### DIFF
--- a/docs/project_status.md
+++ b/docs/project_status.md
@@ -1,29 +1,25 @@
 # Project Status
 
-## Migration status
-- Python-to-Rust module test parity is complete for the tracked mlfinlab suite.
-- Source of truth: `openquant-rs/tests/crosswalk.md`.
-- Roadmap remaining list is empty.
+## Current delivery state (2026-02-13)
+- AFML gap modules tracked in epic `OQ-mef` are implemented in `crates/openquant/src/`:
+  `ensemble_methods`, `hyperparameter_tuning`, `backtesting_engine`, `synthetic_backtesting`,
+  `strategy_risk`, `hpc_parallel`, `combinatorial_optimization`, and `streaming_hpc`.
+- Panic-based public API paths were migrated to typed errors under `OQ-mef.6`.
+- Notebook-first platform artifacts are present:
+  Python bindings (`crates/pyopenquant`), Python API package (`python/openquant`),
+  notebook starter packs (`notebooks/python`, `notebooks/rust`), experiment scaffold (`experiments/`),
+  and CI smoke workflows (`.github/workflows/python-bindings.yml`,
+  `.github/workflows/notebooks-examples-smoke.yml`).
 
-## Do we still need mlfinlab repo locally?
-Short answer: not required for day-to-day OpenQuant usage, still useful for maintenance.
+## Reconciliation status
+- Reconciliation source of truth: `docs/reconciliation_closure_history.md`.
+- Most previously closed deliverables are now present on `main`.
+- Two acceptance-criteria mismatches remain tracked as open follow-ups:
+  - `OQ-ojp`: docs-site notebook workflow page + navigation links.
+  - `OQ-det`: experiment plot artifact outputs and tests.
 
-Keep mlfinlab if you want to:
-- add new parity modules/tests in the future,
-- re-generate fixtures from Python behavior,
-- validate behavior drift against upstream changes.
-
-You can archive/remove mlfinlab locally if you are:
-- focused only on OpenQuant runtime/library usage,
-- not planning additional parity backports,
-- comfortable relying on existing fixtures + Rust tests only.
-
-## Functional status
-OpenQuant is functional for the migrated tracked package scope, with:
-- passing fast/full Rust test sweeps (except intentionally isolated long SADF run in default fast path),
-- benchmark baselines and regression checks,
-- release-readiness CI workflow.
-
-## Known caveats
-- `test_sadf_test` is intentionally excluded from fast CI and run in dedicated slow/nightly path.
-- Performance thresholds are now wired but should be tightened over time as variance stabilizes.
+## Quality and CI posture
+- Core CI workflows are present for lint/test, benchmark regression, release checks, bindings smoke,
+  and notebook/example smoke.
+- Remaining work is focused on documentation-site parity and experiment artifact completeness
+  (tracked by `OQ-ojp` and `OQ-det`).

--- a/docs/reconciliation_closure_history.md
+++ b/docs/reconciliation_closure_history.md
@@ -1,0 +1,54 @@
+# Beads Closure Reconciliation (OQ-mef.10)
+
+Date: 2026-02-13
+
+## Scope
+Reconcile closed issue claims against repository contents on `main` and align tracker/docs state
+to what is actually delivered.
+
+## Evidence Summary
+
+### Python bindings and package track (`OQ-u5h` subtree)
+- `OQ-caa` scaffold claim: present.
+  - Evidence: `crates/pyopenquant/Cargo.toml`, `crates/pyopenquant/src/lib.rs`, `pyproject.toml`.
+- `OQ-xhk` API surface/conversions claim: present.
+  - Evidence: `crates/pyopenquant/src/lib.rs`, `python/openquant/__init__.py`.
+- `OQ-8yl` pytest harness claim: present.
+  - Evidence: `python/tests/test_bindings_contract.py`, `python/tests/test_pipeline_api.py`.
+- `OQ-pqz` CI smoke workflow claim: present.
+  - Evidence: `.github/workflows/python-bindings.yml`.
+- `OQ-alv` install/API docs claim: present.
+  - Evidence: `docs/python_bindings.md`, `README.md` links.
+
+### Notebook-first platform track (`OQ-ruu` subtree)
+- `OQ-2ub` notebook starter pack claim: present.
+  - Evidence: `notebooks/python/*.ipynb`, `notebooks/rust/*.rs`, folder READMEs.
+- `OQ-gz9` adapters/viz claim: present.
+  - Evidence: `python/openquant/adapters.py`, `python/openquant/viz.py`.
+- `OQ-jmo` pipeline claim: present.
+  - Evidence: `crates/openquant/src/pipeline.rs`, `python/openquant/pipeline.py`.
+- `OQ-1na` experiment scaffold claim: partially present.
+  - Present: config + deterministic tabular artifacts + manifest/decision note.
+  - Evidence: `experiments/run_pipeline.py`, `experiments/configs/futures_oil_baseline.toml`,
+    `python/tests/test_experiment_scaffold.py`.
+  - Gap: acceptance explicitly included plot artifacts; current runner does not emit plot files.
+- `OQ-7uk` notebook/example smoke CI claim: present.
+  - Evidence: `.github/workflows/notebooks-examples-smoke.yml`,
+    `crates/openquant/examples/research_notebook_smoke.rs`.
+- `OQ-vuy` workflow docs claim: partially present.
+  - Present: `docs/research_workflow.md`, README links.
+  - Gap: acceptance explicitly required a dedicated docs-site workflow page linked from
+    getting-started/examples; no such page exists under `docs-site/src/pages/`.
+
+## Discrepancies and Tracking Actions
+- Missing docs-site workflow page/linkage:
+  - Follow-up issue created: `OQ-ojp`.
+- Missing plot artifacts in experiment scaffold outputs:
+  - Follow-up issue created: `OQ-det`.
+
+Both follow-ups are linked as `discovered-from` `OQ-mef.10`.
+
+## Conclusion
+- Closed-issue claims for bindings, notebooks, pipeline, and CI smoke are materially present in tree.
+- Two acceptance-criteria gaps remain and are now explicitly tracked as open issues.
+- `docs/project_status.md` has been updated to reflect this reconciled state.


### PR DESCRIPTION
## Summary
- add a written reconciliation note for closed issue claims vs repository evidence (`docs/reconciliation_closure_history.md`)
- update `docs/project_status.md` to reflect current AFML/module + notebook/bindings reality
- track unresolved acceptance mismatches with new issues: `OQ-ojp`, `OQ-det`
- close `OQ-mef.10` and parent epic `OQ-mef` after reconciliation

## Validation
- audited closed beads issues against the current tree and documented evidence
- ran `bd sync` after issue updates and closures