### PR TITLE
docs: stop the site claiming a review that never happened

### DIFF
--- a/docs-site/scripts/check-content-schema.mjs
+++ b/docs-site/scripts/check-content-schema.mjs
@@ -1,7 +1,30 @@
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
 const docsRoot = path.resolve(process.cwd(), 'src/content/docs');
+
+/**
+ * The status taxonomy. The ordering is deliberate: each value claims strictly
+ * more human attention than the one before it.
+ *
+ *   generated — machine-emitted from src/data/moduleDocs.ts. Nobody has read it.
+ *   draft     — hand-written, known to be incomplete. Claims nothing.
+ *   reviewed  — a human read the page and it stands on its own.
+ *   validated — reviewed AND checked against the code it describes.
+ *
+ * Each status names the date field that backs it. `draft` and `generated` cannot
+ * claim `last_validated`, because neither has been validated by anyone — that is
+ * the whole point of the taxonomy, and the gate below enforces it.
+ */
+const STATUS_DATE_FIELD = {
+  generated: 'last_generated',
+  draft: null,
+  reviewed: 'last_validated',
+  validated: 'last_validated',
+};
+const STATUSES = Object.keys(STATUS_DATE_FIELD);
+const DATE_FIELDS = ['last_generated', 'last_validated'];
 
 function walk(dir) {
   const files = [];
@@ -26,29 +49,171 @@ function parseFrontmatter(text) {
   for (const line of raw.split('\n')) {
     if (!line.trim() || line.trim().startsWith('#')) continue;
     const kv = line.match(/^([A-Za-z_][A-Za-z0-9_]*):\s*(.*)$/);
-    if (kv) out[kv[1]] = kv[2];
+    if (kv) out[kv[1]] = unquote(kv[2]);
   }
   return out;
 }
 
+function unquote(value) {
+  const v = String(value).trim();
+  if (v.length >= 2 && (v[0] === "'" || v[0] === '"') && v.at(-1) === v[0]) {
+    return v.slice(1, -1);
+  }
+  return v;
+}
+
+/** A real YYYY-MM-DD date, not merely a string shaped like one (2026-02-31 is not a date). */
+function parseIsoDate(value) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+  const d = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString().slice(0, 10) === value ? d : null;
+}
+
+function git(args, cwd) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+/**
+ * Last date each doc actually changed — the newer of its last commit date and,
+ * when the working tree copy differs from HEAD (or is untracked), its filesystem
+ * mtime. Uncommitted edits count: otherwise you could edit a page and keep a
+ * stale stamp green right up until the moment you commit.
+ *
+ * Returns a Map of absolute path -> YYYY-MM-DD, or null if this is not a git
+ * checkout (in which case freshness is checked against mtime alone).
+ */
+function lastChangedDates(files) {
+  const dates = new Map();
+  const mtimeDay = (file) => fs.statSync(file).mtime.toISOString().slice(0, 10);
+
+  let repoRoot;
+  try {
+    repoRoot = git(['rev-parse', '--show-toplevel'], docsRoot).trim();
+  } catch {
+    // Not a git checkout (a release tarball, say). Fall back to mtime for everything.
+    for (const file of files) dates.set(file, mtimeDay(file));
+    return dates;
+  }
+
+  // One `git log` walk over the whole docs tree rather than one subprocess per
+  // file. Commits are newest-first, so the first time a path appears is its most
+  // recent change.
+  const log = git(
+    ['log', '--pretty=format:%x00%cI', '--name-only', '--diff-filter=d', '--', docsRoot],
+    repoRoot
+  );
+  let commitDay = null;
+  for (const line of log.split('\n')) {
+    if (line.startsWith('\0')) {
+      commitDay = line.slice(1, 11);
+      continue;
+    }
+    if (!line.trim() || !commitDay) continue;
+    const abs = path.resolve(repoRoot, line.trim());
+    if (!dates.has(abs)) dates.set(abs, commitDay);
+  }
+
+  // Anything modified or untracked in the working tree is at least as new as its mtime.
+  const status = git(['status', '--porcelain', '--', docsRoot], repoRoot);
+  for (const line of status.split('\n')) {
+    if (!line.trim()) continue;
+    const rel = line.slice(3).split(' -> ').at(-1).replace(/^"|"$/g, '');
+    const abs = path.resolve(repoRoot, rel);
+    if (!fs.existsSync(abs) || fs.statSync(abs).isDirectory()) continue;
+    const day = mtimeDay(abs);
+    if (!dates.has(abs) || day > dates.get(abs)) dates.set(abs, day);
+  }
+
+  for (const file of files) {
+    if (!dates.has(file)) dates.set(file, mtimeDay(file));
+  }
+  return dates;
+}
+
 const files = walk(docsRoot);
-const missing = [];
+const changed = lastChangedDates(files);
+const errors = [];
 
 for (const file of files) {
-  const text = fs.readFileSync(file, 'utf8');
-  const fm = parseFrontmatter(text);
-  const required = ['title', 'description', 'status', 'last_validated'];
-  for (const key of required) {
-    if (!(key in fm) || String(fm[key]).trim() === '') {
-      missing.push(`${path.relative(process.cwd(), file)} missing ${key}`);
+  const rel = path.relative(process.cwd(), file);
+  const fm = parseFrontmatter(fs.readFileSync(file, 'utf8'));
+  const fail = (msg) => errors.push(`${rel}: ${msg}`);
+
+  for (const key of ['title', 'description', 'status']) {
+    if (!(key in fm) || fm[key].trim() === '') fail(`missing ${key}`);
+  }
+
+  const status = fm.status;
+  if (status === undefined || status.trim() === '') continue;
+
+  if (!STATUSES.includes(status)) {
+    fail(
+      `status: ${status} is not one of ${STATUSES.join(' | ')}. ` +
+        `Use 'generated' for machine-emitted pages, 'draft' for hand-written pages ` +
+        `that are not finished, 'reviewed' once a human has read the page, and ` +
+        `'validated' once it has also been checked against the code.`
+    );
+    continue;
+  }
+
+  // Every date present must be a real ISO date, whether or not this status needs it.
+  for (const field of DATE_FIELDS) {
+    if (field in fm && !parseIsoDate(fm[field])) {
+      fail(`${field}: ${fm[field]} is not a valid ISO date (expected YYYY-MM-DD)`);
     }
+  }
+
+  const dateField = STATUS_DATE_FIELD[status];
+  if (dateField === null) {
+    if ('last_validated' in fm) {
+      fail(
+        `status: draft must not carry last_validated — a draft has not been ` +
+          `validated by anyone. Drop the field, or raise the status to 'reviewed'.`
+      );
+    }
+    continue;
+  }
+
+  if (!(dateField in fm) || fm[dateField].trim() === '') {
+    fail(`status: ${status} requires ${dateField} (YYYY-MM-DD)`);
+    continue;
+  }
+
+  const stamped = parseIsoDate(fm[dateField]);
+  if (!stamped) continue; // already reported above
+
+  // The rule that makes the stamp mean something: a page cannot claim to have
+  // been reviewed or generated BEFORE the last time its content actually changed.
+  // Without this, `status: validated` is just a string anyone can paste, and can
+  // be bulk-applied to a whole corpus — which is exactly how this site ended up
+  // with 59 pages sharing one hardcoded review date.
+  const changedOn = changed.get(file);
+  if (changedOn && changedOn > fm[dateField]) {
+    const what =
+      status === 'generated'
+        ? `Re-run 'node scripts/generate-module-doc-pages.mjs' to re-stamp it`
+        : `Re-read the page; if it still stands, set ${dateField}: '${changedOn}'. ` +
+          `If you have not re-read it, lower the status to 'draft' instead of ` +
+          `bumping the date`;
+    fail(
+      `stale ${dateField}: page last changed ${changedOn} but claims ` +
+        `${dateField}: '${fm[dateField]}'. The content moved after the ` +
+        `stamp, so the stamp no longer describes this page. ${what}.`
+    );
   }
 }
 
-if (missing.length) {
-  console.error('Content schema check failed:');
-  for (const err of missing) console.error(`- ${err}`);
+if (errors.length) {
+  console.error(`Content schema check FAILED (${errors.length} problem(s)):`);
+  for (const err of errors) console.error(`- ${err}`);
   process.exit(1);
 }
 
-console.log(`Content schema check passed (${files.length} docs files).`);
+const tally = {};
+for (const file of files) {
+  const s = parseFrontmatter(fs.readFileSync(file, 'utf8')).status ?? '(none)';
+  tally[s] = (tally[s] ?? 0) + 1;
+}
+const summary = STATUSES.filter((s) => tally[s]).map((s) => `${tally[s]} ${s}`).join(', ');
+console.log(`Content schema check passed (${files.length} docs files: ${summary}).`);

--- a/docs-site/scripts/check-content-schema.mjs
+++ b/docs-site/scripts/check-content-schema.mjs
@@ -80,8 +80,8 @@ function git(args, cwd) {
  * mtime. Uncommitted edits count: otherwise you could edit a page and keep a
  * stale stamp green right up until the moment you commit.
  *
- * Returns a Map of absolute path -> YYYY-MM-DD, or null if this is not a git
- * checkout (in which case freshness is checked against mtime alone).
+ * Returns a Map of absolute path -> YYYY-MM-DD. Outside a git checkout (a release
+ * tarball, say) freshness falls back to mtime alone.
  */
 function lastChangedDates(files) {
   const dates = new Map();
@@ -137,7 +137,9 @@ const errors = [];
 
 for (const file of files) {
   const rel = path.relative(process.cwd(), file);
-  const fm = parseFrontmatter(fs.readFileSync(file, 'utf8'));
+  const text = fs.readFileSync(file, 'utf8');
+  const frontmatter = text.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? '';
+  const fm = parseFrontmatter(text);
   const fail = (msg) => errors.push(`${rel}: ${msg}`);
 
   for (const key of ['title', 'description', 'status']) {
@@ -155,6 +157,16 @@ for (const file of files) {
         `'validated' once it has also been checked against the code.`
     );
     continue;
+  }
+
+  // The reader-facing badge is rendered from the page's own banner frontmatter,
+  // so it can drift from `status` unless something checks. This is that check.
+  const badge = frontmatter.match(/doc-status--([a-z]+)/)?.[1];
+  if (badge && badge !== status) {
+    fail(
+      `status: ${status} but the reader-facing badge says '${badge}'. ` +
+        `Update the banner content so the badge matches the frontmatter status.`
+    );
   }
 
   // Every date present must be a real ISO date, whether or not this status needs it.

--- a/docs-site/scripts/generate-module-doc-pages.mjs
+++ b/docs-site/scripts/generate-module-doc-pages.mjs
@@ -155,6 +155,8 @@ description: ${q(doc.summary)}
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '${generatedOn}'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering
@@ -201,6 +203,8 @@ description: "Full OpenQuant module documentation index with AFML-aligned summar
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '${generatedOn}'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/scripts/generate-module-doc-pages.mjs
+++ b/docs-site/scripts/generate-module-doc-pages.mjs
@@ -5,6 +5,13 @@ import { moduleDocs } from '../src/data/moduleDocs.ts';
 const outDir = path.resolve(process.cwd(), 'src/content/docs/modules');
 fs.mkdirSync(outDir, { recursive: true });
 
+// These pages are machine-emitted from src/data/moduleDocs.ts and have not been read
+// by a human, so they may only ever claim 'generated' — never 'reviewed' or 'validated'.
+// Those stronger statuses are reachable only by a person deliberately editing a page.
+// Date-only, so repeated runs on the same day are byte-identical (the generator must
+// stay idempotent) and so the stamp is comparable with the schema gate's mtime rule.
+const generatedOn = new Date().toISOString().slice(0, 10);
+
 const q = (value) => JSON.stringify(String(value));
 const toYamlList = (values) => values.map((v) => `  - ${q(v)}`).join('\n');
 
@@ -145,8 +152,9 @@ for (const doc of moduleDocs) {
   const content = `---
 title: ${q(doc.module)}
 description: ${q(doc.summary)}
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '${generatedOn}'
 audience:
   - quant-dev
   - platform-engineering
@@ -190,8 +198,9 @@ const groupedIndex = [...bySubject.entries()]
 const indexContent = `---
 title: "Module Reference Index"
 description: "Full OpenQuant module documentation index with AFML-aligned summaries."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '${generatedOn}'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/config.ts
+++ b/docs-site/src/content/config.ts
@@ -5,7 +5,13 @@ const docs = defineCollection({
   schema: docsSchema({
     extend: z.object({
       audience: z.array(z.string()).optional(),
-      status: z.enum(['draft', 'in_review', 'validated']).optional(),
+      // Kept in step with STATUS_DATE_FIELD in scripts/check-content-schema.mjs,
+      // which additionally enforces that the date backing a status is real and is
+      // not older than the page's last change. Required, not optional: a page with
+      // no status is a page making an unexamined claim by omission.
+      status: z.enum(['generated', 'draft', 'reviewed', 'validated']),
+      last_generated: z.string().optional(),
+      generated_from: z.string().optional(),
       last_validated: z.string().optional(),
       module: z.string().optional(),
       afml_chapter: z.array(z.string()).optional(),

--- a/docs-site/src/content/docs/coverage.md
+++ b/docs-site/src/content/docs/coverage.md
@@ -1,8 +1,7 @@
 ---
 title: Coverage Dashboard
 description: AFML-aligned documentation coverage checkpoints and current completeness status.
-status: validated
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/coverage.md
+++ b/docs-site/src/content/docs/coverage.md
@@ -2,6 +2,8 @@
 title: Coverage Dashboard
 description: AFML-aligned documentation coverage checkpoints and current completeness status.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/examples/catalog.md
+++ b/docs-site/src/content/docs/examples/catalog.md
@@ -2,6 +2,8 @@
 title: Examples Catalog
 description: Example entry points grouped by workflow stage.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/examples/catalog.md
+++ b/docs-site/src/content/docs/examples/catalog.md
@@ -1,8 +1,7 @@
 ---
 title: Examples Catalog
 description: Example entry points grouped by workflow stage.
-status: in_review
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/governance/benchmark-policy.md
+++ b/docs-site/src/content/docs/governance/benchmark-policy.md
@@ -2,6 +2,8 @@
 title: Benchmark Policy
 description: Performance benchmarking and regression guardrails.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/governance/benchmark-policy.md
+++ b/docs-site/src/content/docs/governance/benchmark-policy.md
@@ -1,8 +1,7 @@
 ---
 title: Benchmark Policy
 description: Performance benchmarking and regression guardrails.
-status: validated
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/governance/methodology-and-leakage-controls.md
+++ b/docs-site/src/content/docs/governance/methodology-and-leakage-controls.md
@@ -3,6 +3,8 @@ title: Methodology and Leakage Controls
 description: Required anti-leakage and methodology controls for OpenQuant research and evaluation.
 status: reviewed
 last_validated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--reviewed">Reviewed</span> A human has read this page end to end. It has not been verified line by line against the code.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/governance/methodology-and-leakage-controls.md
+++ b/docs-site/src/content/docs/governance/methodology-and-leakage-controls.md
@@ -1,8 +1,8 @@
 ---
 title: Methodology and Leakage Controls
 description: Required anti-leakage and methodology controls for OpenQuant research and evaluation.
-status: validated
-last_validated: '2026-03-02'
+status: reviewed
+last_validated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/governance/reproducibility-and-artifact-contracts.md
+++ b/docs-site/src/content/docs/governance/reproducibility-and-artifact-contracts.md
@@ -1,8 +1,8 @@
 ---
 title: Reproducibility and Artifact Contracts
 description: Minimum artifact and metadata contract for reproducible research outcomes.
-status: validated
-last_validated: '2026-03-02'
+status: reviewed
+last_validated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/governance/reproducibility-and-artifact-contracts.md
+++ b/docs-site/src/content/docs/governance/reproducibility-and-artifact-contracts.md
@@ -3,6 +3,8 @@ title: Reproducibility and Artifact Contracts
 description: Minimum artifact and metadata contract for reproducible research outcomes.
 status: reviewed
 last_validated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--reviewed">Reviewed</span> A human has read this page end to end. It has not been verified line by line against the code.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/governance/support-and-escalation.md
+++ b/docs-site/src/content/docs/governance/support-and-escalation.md
@@ -2,6 +2,8 @@
 title: Support and Escalation
 description: Operational support entry points and escalation expectations.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/governance/support-and-escalation.md
+++ b/docs-site/src/content/docs/governance/support-and-escalation.md
@@ -1,8 +1,7 @@
 ---
 title: Support and Escalation
 description: Operational support entry points and escalation expectations.
-status: in_review
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/governance/versioning-and-release-policy.md
+++ b/docs-site/src/content/docs/governance/versioning-and-release-policy.md
@@ -1,8 +1,7 @@
 ---
 title: Versioning and Release Policy
 description: Release and documentation versioning policy for OpenQuant.
-status: validated
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/governance/versioning-and-release-policy.md
+++ b/docs-site/src/content/docs/governance/versioning-and-release-policy.md
@@ -2,6 +2,8 @@
 title: Versioning and Release Policy
 description: Release and documentation versioning policy for OpenQuant.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/index.md
+++ b/docs-site/src/content/docs/index.md
@@ -17,8 +17,8 @@ hero:
     - text: Browse Modules
       link: /openquant/modules/
       variant: minimal
-status: validated
-last_validated: '2026-03-02'
+status: reviewed
+last_validated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/index.md
+++ b/docs-site/src/content/docs/index.md
@@ -19,6 +19,8 @@ hero:
       variant: minimal
 status: reviewed
 last_validated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--reviewed">Reviewed</span> A human has read this page end to end. It has not been verified line by line against the code.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/index.md
+++ b/docs-site/src/content/docs/index.md
@@ -3,8 +3,7 @@ title: OpenQuant Documentation
 description: Production-grade documentation for AFML-aligned quantitative research and portfolio engineering with OpenQuant.
 template: splash
 banner:
-  content: |
-    <a href="/openquant/quickstart/">New to OpenQuant? Start with the Quickstart guide →</a>
+  content: '<span class="doc-status doc-status--reviewed">Reviewed</span> <a href="/openquant/quickstart/">New to OpenQuant? Start with the Quickstart guide →</a>'
 hero:
   title: OpenQuant Documentation
   tagline: Institutional-grade quantitative research documentation aligned to AFML chapters and production deployment controls.
@@ -19,8 +18,6 @@ hero:
       variant: minimal
 status: reviewed
 last_validated: '2026-08-30'
-banner:
-  content: '<span class="doc-status doc-status--reviewed">Reviewed</span> A human has read this page end to end. It has not been verified line by line against the code.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/module-reference/api-surfaces.md
+++ b/docs-site/src/content/docs/module-reference/api-surfaces.md
@@ -2,6 +2,8 @@
 title: API Surfaces
 description: High-level Rust and Python API surface map for core workflows.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/module-reference/api-surfaces.md
+++ b/docs-site/src/content/docs/module-reference/api-surfaces.md
@@ -1,8 +1,7 @@
 ---
 title: API Surfaces
 description: High-level Rust and Python API surface map for core workflows.
-status: validated
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/module-reference/by-afml-chapter.md
+++ b/docs-site/src/content/docs/module-reference/by-afml-chapter.md
@@ -1,8 +1,8 @@
 ---
 title: By AFML Chapter
 description: Map AFML concepts to concrete OpenQuant modules and workflows.
-status: validated
-last_validated: '2026-03-02'
+status: reviewed
+last_validated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/module-reference/by-afml-chapter.md
+++ b/docs-site/src/content/docs/module-reference/by-afml-chapter.md
@@ -3,6 +3,8 @@ title: By AFML Chapter
 description: Map AFML concepts to concrete OpenQuant modules and workflows.
 status: reviewed
 last_validated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--reviewed">Reviewed</span> A human has read this page end to end. It has not been verified line by line against the code.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/module-reference/indexing-and-discovery.md
+++ b/docs-site/src/content/docs/module-reference/indexing-and-discovery.md
@@ -1,8 +1,7 @@
 ---
 title: Indexing and Discovery
 description: Navigation model and search strategy for fast access to core OpenQuant capabilities.
-status: validated
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/module-reference/indexing-and-discovery.md
+++ b/docs-site/src/content/docs/module-reference/indexing-and-discovery.md
@@ -2,6 +2,8 @@
 title: Indexing and Discovery
 description: Navigation model and search strategy for fast access to core OpenQuant capabilities.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/adapters.md
+++ b/docs-site/src/content/docs/modules/adapters.md
@@ -4,6 +4,8 @@ description: "Polars DataFrame adapters for signals, events, weights, backtest c
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/adapters.md
+++ b/docs-site/src/content/docs/modules/adapters.md
@@ -1,8 +1,9 @@
 ---
 title: "adapters"
 description: "Polars DataFrame adapters for signals, events, weights, backtest curves, and streaming buffers."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/backtest-statistics.md
+++ b/docs-site/src/content/docs/modules/backtest-statistics.md
@@ -4,6 +4,8 @@ description: "Performance diagnostics for strategy returns and position trajecto
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/backtest-statistics.md
+++ b/docs-site/src/content/docs/modules/backtest-statistics.md
@@ -1,12 +1,14 @@
 ---
 title: "backtest_statistics"
 description: "Performance diagnostics for strategy returns and position trajectories."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "backtest_statistics"
+api_surface: "both"
 risk_notes:
   - "Use annualization constants consistent with your bar frequency."
   - "Deflated Sharpe is useful when strategy mining many variants."
@@ -54,6 +56,19 @@ println!("{sr} {dd:?} {tuw:?}");
 ```
 
 ## API Reference
+
+### Python API
+
+- `backtest_stats.sharpe_ratio`
+- `backtest_stats.information_ratio`
+- `backtest_stats.probabilistic_sharpe_ratio`
+- `backtest_stats.deflated_sharpe_ratio`
+- `backtest_stats.minimum_track_record_length`
+- `backtest_stats.timing_of_flattening_and_flips`
+- `backtest_stats.average_holding_period`
+- `backtest_stats.bets_concentration`
+- `backtest_stats.all_bets_concentration`
+- `backtest_stats.drawdown_and_time_under_water`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/backtesting-engine.md
+++ b/docs-site/src/content/docs/modules/backtesting-engine.md
@@ -4,6 +4,8 @@ description: "Backtesting core with walk-forward, purged CV, and combinatorial p
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/backtesting-engine.md
+++ b/docs-site/src/content/docs/modules/backtesting-engine.md
@@ -1,8 +1,9 @@
 ---
 title: "backtesting_engine"
 description: "Backtesting core with walk-forward, purged CV, and combinatorial purged CV (CPCV) workflows."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/bet-sizing.md
+++ b/docs-site/src/content/docs/modules/bet-sizing.md
@@ -1,12 +1,14 @@
 ---
 title: "bet_sizing"
 description: "Transforms model confidence and constraints into executable position sizes."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "bet_sizing"
+api_surface: "both"
 risk_notes:
   - "Keep sizing logic coupled to latency and fill assumptions; limit price from dynamic sizing is a decision boundary, not a guaranteed fill."
   - "Use reserve sizing when overlapping books or strategy stacking can create hidden gross exposure."
@@ -102,6 +104,37 @@ assert!(!reserve.is_empty());
 ```
 
 ## API Reference
+
+### Python API
+
+- `bet_sizing.get_signal`
+- `bet_sizing.discrete_signal`
+- `bet_sizing.bet_size`
+- `bet_sizing.bet_size_sigmoid`
+- `bet_sizing.bet_size_power`
+- `bet_sizing.inv_price`
+- `bet_sizing.inv_price_sigmoid`
+- `bet_sizing.inv_price_power`
+- `bet_sizing.get_w`
+- `bet_sizing.get_w_sigmoid`
+- `bet_sizing.get_w_power`
+- `bet_sizing.get_target_pos`
+- `bet_sizing.get_target_pos_sigmoid`
+- `bet_sizing.get_target_pos_power`
+- `bet_sizing.limit_price`
+- `bet_sizing.limit_price_sigmoid`
+- `bet_sizing.limit_price_power`
+- `bet_sizing.avg_active_signals`
+- `bet_sizing.bet_size_dynamic`
+- `bet_sizing.cdf_mixture`
+- `bet_sizing.single_bet_size_mixed`
+- `bet_sizing.get_concurrent_sides`
+- `bet_sizing.bet_size_budget`
+- `bet_sizing.bet_size_probability`
+- `bet_sizing.mp_avg_active_signals`
+- `bet_sizing.bet_size_reserve`
+- `bet_sizing.bet_size_reserve_with_fit`
+- `bet_sizing.bet_size_reserve_full`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/bet-sizing.md
+++ b/docs-site/src/content/docs/modules/bet-sizing.md
@@ -4,6 +4,8 @@ description: "Transforms model confidence and constraints into executable positi
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/cla.md
+++ b/docs-site/src/content/docs/modules/cla.md
@@ -4,6 +4,8 @@ description: "Critical Line Algorithm implementation for constrained mean-varian
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/cla.md
+++ b/docs-site/src/content/docs/modules/cla.md
@@ -1,12 +1,14 @@
 ---
 title: "cla"
 description: "Critical Line Algorithm implementation for constrained mean-variance optimization."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "cla"
+api_surface: "both"
 risk_notes:
   - "CLA behavior depends on weight bounds and return estimates."
   - "Use robust covariance estimators when sample size is small."
@@ -51,6 +53,10 @@ let sigma = covariance(&returns);
 ```
 
 ## API Reference
+
+### Python API
+
+- `cla.allocate_cla`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/codependence.md
+++ b/docs-site/src/content/docs/modules/codependence.md
@@ -4,6 +4,8 @@ description: "Dependence metrics beyond linear correlation for feature and asset
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/codependence.md
+++ b/docs-site/src/content/docs/modules/codependence.md
@@ -1,12 +1,14 @@
 ---
 title: "codependence"
 description: "Dependence metrics beyond linear correlation for feature and asset relationships."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "codependence"
+api_surface: "both"
 risk_notes:
   - "Use with clustering and feature pruning workflows."
   - "Bin selection materially impacts MI estimates."
@@ -52,6 +54,16 @@ let dcor = distance_correlation(&x, &y)?;
 ```
 
 ## API Reference
+
+### Python API
+
+- `codependence.angular_distance`
+- `codependence.absolute_angular_distance`
+- `codependence.squared_angular_distance`
+- `codependence.distance_correlation`
+- `codependence.get_optimal_number_of_bins`
+- `codependence.get_mutual_info`
+- `codependence.variation_of_information_score`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/combinatorial-optimization.md
+++ b/docs-site/src/content/docs/modules/combinatorial-optimization.md
@@ -4,6 +4,8 @@ description: "AFML Chapter 21 integer-encoded optimization and trajectory state-
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/combinatorial-optimization.md
+++ b/docs-site/src/content/docs/modules/combinatorial-optimization.md
@@ -1,12 +1,14 @@
 ---
 title: "combinatorial_optimization"
 description: "AFML Chapter 21 integer-encoded optimization and trajectory state-space tooling with exact baselines and solver adapters."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "combinatorial_optimization"
+api_surface: "rust-only"
 risk_notes:
   - "Exact enumeration scales exponentially in decision dimension/horizon; treat it as a correctness baseline and regression oracle."
   - "Use adapter interfaces to compare heuristic/external solvers against exact solutions on small calibration instances before production deployment."

--- a/docs-site/src/content/docs/modules/cross-validation.md
+++ b/docs-site/src/content/docs/modules/cross-validation.md
@@ -4,6 +4,8 @@ description: "Purged cross-validation utilities designed for label overlap and l
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/cross-validation.md
+++ b/docs-site/src/content/docs/modules/cross-validation.md
@@ -1,12 +1,14 @@
 ---
 title: "cross_validation"
 description: "Purged cross-validation utilities designed for label overlap and leakage control."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "cross_validation"
+api_surface: "rust-only"
 risk_notes:
   - "Always align event end-times when purging."
   - "Report variance across folds, not only mean score."

--- a/docs-site/src/content/docs/modules/data-structures.md
+++ b/docs-site/src/content/docs/modules/data-structures.md
@@ -4,6 +4,8 @@ description: "Constructs standard/time/run/imbalance bars from trade streams."
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/data-structures.md
+++ b/docs-site/src/content/docs/modules/data-structures.md
@@ -1,8 +1,9 @@
 ---
 title: "data_structures"
 description: "Constructs standard/time/run/imbalance bars from trade streams."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
@@ -118,10 +119,10 @@ let t_bars = time_bars(&trades, Duration::minutes(5));
 // Dollar bars via standard_bars
 let d_bars = standard_bars(&trades, 50_000.0, StandardBarType::Dollar);
 
-// Run bars
+// Run bars (Rust-only)
 let r_bars = run_bars(&trades, 100);
 
-// Tick imbalance bars
+// Tick imbalance bars (Rust-only)
 let ib = imbalance_bars(&trades, 500.0, ImbalanceBarType::Tick);
 ```
 
@@ -131,7 +132,7 @@ let ib = imbalance_bars(&trades, 500.0, ImbalanceBarType::Tick);
 - Setting the threshold too low, creating extremely noisy high-frequency bars, or too high, losing intraday resolution.
 - Forgetting to assign trade direction (buy/sell sign) before constructing imbalance or run bars — these require signed volume.
 - Mixing bar types across train and inference: if you train on dollar bars, your live pipeline must also use dollar bars with the same threshold.
-- Run bars and imbalance bars are available in Python via `bars.build_run_bars` and `bars.build_imbalance_bars`.
+- Run bars and imbalance bars are available in Python via bars.build_run_bars and bars.build_imbalance_bars.
 
 ## API Reference
 
@@ -143,7 +144,6 @@ let ib = imbalance_bars(&trades, 500.0, ImbalanceBarType::Tick);
 - `bars.build_dollar_bars`
 - `bars.build_run_bars`
 - `bars.build_imbalance_bars`
-- `bars.bar_diagnostics`
 
 ### Rust API
 
@@ -160,7 +160,7 @@ let ib = imbalance_bars(&trades, 500.0, ImbalanceBarType::Tick);
 
 - Threshold selection controls bar frequency and noise level.
 - Keep OHLCV semantics consistent across downstream features.
-- Run bars and imbalance bars are available via `bars.build_run_bars` and `bars.build_imbalance_bars`.
+- Run bars and imbalance bars are available via bars.build_run_bars and bars.build_imbalance_bars.
 - `bar_diagnostics` is Python-only; use it to verify low return autocorrelation after bar construction.
 
 ## Related Modules

--- a/docs-site/src/content/docs/modules/data.md
+++ b/docs-site/src/content/docs/modules/data.md
@@ -4,6 +4,8 @@ description: "OHLCV loading, cleaning, calendar alignment, and data quality repo
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/data.md
+++ b/docs-site/src/content/docs/modules/data.md
@@ -1,13 +1,14 @@
 ---
 title: "data"
 description: "OHLCV loading, cleaning, calendar alignment, and data quality reporting."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "data"
-api_surface: "python-only"
+api_surface: "both"
 risk_notes:
   - "Column aliases are resolved automatically (e.g., 'timestamp' → 'ts', 'ticker' → 'symbol')."
   - "clean_ohlcv deduplicates by (symbol, ts) and sorts chronologically."
@@ -80,8 +81,11 @@ quality = data_quality_report(df)
 - `data.clean_ohlcv`
 - `data.align_calendar`
 - `data.data_quality_report`
+- `data.clean_ohlcv_df`
+- `data.quality_report_df`
+- `data.align_calendar_df`
 
-### Key Functions
+### Rust API
 
 - `load_ohlcv`
 - `clean_ohlcv`

--- a/docs-site/src/content/docs/modules/ef3m.md
+++ b/docs-site/src/content/docs/modules/ef3m.md
@@ -1,12 +1,14 @@
 ---
 title: "ef3m"
 description: "Moment-based mixture fitting utilities for two-normal components."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "ef3m"
+api_surface: "both"
 risk_notes:
   - "Use as initialization for more expensive optimizers."
   - "Sensitive to higher-moment estimation noise."
@@ -51,6 +53,13 @@ let m3 = centered_moment(&moments, 3);
 ```
 
 ## API Reference
+
+### Python API
+
+- `ef3m.centered_moment`
+- `ef3m.raw_moment`
+- `ef3m.most_likely_parameters`
+- `ef3m.fit_m2n`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/ef3m.md
+++ b/docs-site/src/content/docs/modules/ef3m.md
@@ -4,6 +4,8 @@ description: "Moment-based mixture fitting utilities for two-normal components."
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/ensemble-methods.md
+++ b/docs-site/src/content/docs/modules/ensemble-methods.md
@@ -4,6 +4,8 @@ description: "Bias/variance diagnostics and practical bagging-vs-boosting ensemb
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/ensemble-methods.md
+++ b/docs-site/src/content/docs/modules/ensemble-methods.md
@@ -1,12 +1,14 @@
 ---
 title: "ensemble_methods"
 description: "Bias/variance diagnostics and practical bagging-vs-boosting ensemble utilities."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "ensemble_methods"
+api_surface: "both"
 risk_notes:
   - "If base learners are highly correlated, bagging variance reduction is minimal even with many estimators."
   - "Sequential-bootstrap-style sampling is preferable under heavy label overlap and non-IID observations."
@@ -98,6 +100,18 @@ assert_eq!(mean_prob.len(), 3);
 ```
 
 ## API Reference
+
+### Python API
+
+- `ensemble.bias_variance_noise`
+- `ensemble.bootstrap_sample_indices`
+- `ensemble.sequential_bootstrap_sample_indices`
+- `ensemble.aggregate_regression_mean`
+- `ensemble.aggregate_classification_vote`
+- `ensemble.aggregate_classification_probability_mean`
+- `ensemble.average_pairwise_prediction_correlation`
+- `ensemble.bagging_ensemble_variance`
+- `ensemble.recommend_bagging_vs_boosting`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/etf-trick.md
+++ b/docs-site/src/content/docs/modules/etf-trick.md
@@ -1,8 +1,9 @@
 ---
 title: "etf_trick"
 description: "Synthetic ETF and futures roll utilities for realistic PnL path construction."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/etf-trick.md
+++ b/docs-site/src/content/docs/modules/etf-trick.md
@@ -4,6 +4,8 @@ description: "Synthetic ETF and futures roll utilities for realistic PnL path co
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/feature-diagnostics.md
+++ b/docs-site/src/content/docs/modules/feature-diagnostics.md
@@ -1,8 +1,9 @@
 ---
 title: "feature_diagnostics"
 description: "Feature importance diagnostics: MDI, MDA, SFI, PCA orthogonalization, and substitution-effect analysis."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/feature-diagnostics.md
+++ b/docs-site/src/content/docs/modules/feature-diagnostics.md
@@ -4,6 +4,8 @@ description: "Feature importance diagnostics: MDI, MDA, SFI, PCA orthogonalizati
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/feature-importance.md
+++ b/docs-site/src/content/docs/modules/feature-importance.md
@@ -4,6 +4,8 @@ description: "Feature ranking methods: MDI, MDA, and single-feature importance w
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/feature-importance.md
+++ b/docs-site/src/content/docs/modules/feature-importance.md
@@ -1,12 +1,14 @@
 ---
 title: "feature_importance"
 description: "Feature ranking methods: MDI, MDA, and single-feature importance with PCA diagnostics."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "feature_importance"
+api_surface: "rust-only"
 risk_notes:
   - "Cross-validated MDA is preferred when leakage risk is high."
   - "Compare ranking stability across folds/time windows."

--- a/docs-site/src/content/docs/modules/filters.md
+++ b/docs-site/src/content/docs/modules/filters.md
@@ -4,6 +4,8 @@ description: "CUSUM and z-score event filters for event-driven sampling."
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/filters.md
+++ b/docs-site/src/content/docs/modules/filters.md
@@ -1,8 +1,9 @@
 ---
 title: "filters"
 description: "CUSUM and z-score event filters for event-driven sampling."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/fingerprint.md
+++ b/docs-site/src/content/docs/modules/fingerprint.md
@@ -4,6 +4,8 @@ description: "Model fingerprinting for linear, non-linear, and pairwise feature 
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/fingerprint.md
+++ b/docs-site/src/content/docs/modules/fingerprint.md
@@ -1,12 +1,14 @@
 ---
 title: "fingerprint"
 description: "Model fingerprinting for linear, non-linear, and pairwise feature effects."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "fingerprint"
+api_surface: "rust-only"
 risk_notes:
   - "Compare fingerprints across retrains for drift detection."
   - "Use pairwise effects to detect hidden interaction risk."

--- a/docs-site/src/content/docs/modules/fracdiff.md
+++ b/docs-site/src/content/docs/modules/fracdiff.md
@@ -4,6 +4,8 @@ description: "Fractional differentiation to improve stationarity while retaining
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/fracdiff.md
+++ b/docs-site/src/content/docs/modules/fracdiff.md
@@ -1,8 +1,9 @@
 ---
 title: "fracdiff"
 description: "Fractional differentiation to improve stationarity while retaining memory."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
@@ -95,10 +96,10 @@ let out = frac_diff_ffd(&series, 0.4, 1e-4);
 
 ### Python API
 
-- `fracdiff.frac_diff_ffd`
-- `fracdiff.frac_diff`
-- `fracdiff.get_weights_ffd`
 - `fracdiff.get_weights`
+- `fracdiff.get_weights_ffd`
+- `fracdiff.frac_diff`
+- `fracdiff.frac_diff_ffd`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/hcaa.md
+++ b/docs-site/src/content/docs/modules/hcaa.md
@@ -4,6 +4,8 @@ description: "Hierarchical Clustering Asset Allocation variant with cluster-leve
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/hcaa.md
+++ b/docs-site/src/content/docs/modules/hcaa.md
@@ -1,12 +1,14 @@
 ---
 title: "hcaa"
 description: "Hierarchical Clustering Asset Allocation variant with cluster-level constraints."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "hcaa"
+api_surface: "both"
 risk_notes:
   - "Cluster linkage choices influence allocations."
   - "Use with robust codependence distances when possible."
@@ -49,6 +51,10 @@ let w = hcaa.allocate(&prices)?;
 ```
 
 ## API Reference
+
+### Python API
+
+- `hcaa.allocate_hcaa`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/hpc-parallel.md
+++ b/docs-site/src/content/docs/modules/hpc-parallel.md
@@ -4,6 +4,8 @@ description: "AFML Chapter 20 atom/molecule execution utilities with serial/thre
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/hpc-parallel.md
+++ b/docs-site/src/content/docs/modules/hpc-parallel.md
@@ -1,12 +1,14 @@
 ---
 title: "hpc_parallel"
 description: "AFML Chapter 20 atom/molecule execution utilities with serial/threaded modes and partition diagnostics."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "hpc_parallel"
+api_surface: "rust-only"
 risk_notes:
   - "Use `ExecutionMode::Serial` for deterministic debugging with identical callback semantics."
   - "If per-atom cost rises with atom index (e.g., expanding windows), nested partitioning can reduce tail stragglers versus linear chunking."

--- a/docs-site/src/content/docs/modules/hrp.md
+++ b/docs-site/src/content/docs/modules/hrp.md
@@ -1,12 +1,14 @@
 ---
 title: "hrp"
 description: "Hierarchical Risk Parity allocation with recursive bisection."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "hrp"
+api_surface: "both"
 risk_notes:
   - "HRP is often more robust under unstable covariance estimates."
   - "Ensure input asset order tracks produced dendrogram order."
@@ -49,6 +51,10 @@ let weights = hrp.allocate(&prices)?;
 ```
 
 ## API Reference
+
+### Python API
+
+- `hrp.allocate_hrp`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/hrp.md
+++ b/docs-site/src/content/docs/modules/hrp.md
@@ -4,6 +4,8 @@ description: "Hierarchical Risk Parity allocation with recursive bisection."
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/hyperparameter-tuning.md
+++ b/docs-site/src/content/docs/modules/hyperparameter-tuning.md
@@ -4,6 +4,8 @@ description: "Leakage-aware grid/randomized hyper-parameter search with purged C
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/hyperparameter-tuning.md
+++ b/docs-site/src/content/docs/modules/hyperparameter-tuning.md
@@ -1,12 +1,14 @@
 ---
 title: "hyperparameter_tuning"
 description: "Leakage-aware grid/randomized hyper-parameter search with purged CV and weighted scoring."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "hyperparameter_tuning"
+api_surface: "rust-only"
 risk_notes:
   - "Use Accuracy only when each prediction has similar economic value (equal bet sizing)."
   - "Prefer weighted NegLogLoss when probabilities drive position sizing or outcomes have different economic magnitude."

--- a/docs-site/src/content/docs/modules/index.md
+++ b/docs-site/src/content/docs/modules/index.md
@@ -1,8 +1,9 @@
 ---
 title: "Module Reference Index"
 description: "Full OpenQuant module documentation index with AFML-aligned summaries."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/index.md
+++ b/docs-site/src/content/docs/modules/index.md
@@ -4,6 +4,8 @@ description: "Full OpenQuant module documentation index with AFML-aligned summar
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/labeling.md
+++ b/docs-site/src/content/docs/modules/labeling.md
@@ -1,8 +1,9 @@
 ---
 title: "labeling"
 description: "Triple-barrier event labeling and metadata generation."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
@@ -16,8 +17,6 @@ risk_notes:
   - "In meta-labeling, side alignment and timestamp joins are a frequent hidden bug source."
 rust_api:
   - "add_vertical_barrier"
-  - "triple_barrier_events"
-  - "triple_barrier_labels"
   - "get_events"
   - "get_bins"
   - "drop_labels"
@@ -186,10 +185,10 @@ assert!(!meta_bins.is_empty());
 
 ### Python API
 
-- `labeling.add_vertical_barrier`
-- `labeling.triple_barrier_events`
 - `labeling.triple_barrier_labels`
+- `labeling.triple_barrier_events`
 - `labeling.meta_labels`
+- `labeling.add_vertical_barrier`
 - `labeling.get_events`
 - `labeling.get_bins`
 - `labeling.drop_labels`

--- a/docs-site/src/content/docs/modules/labeling.md
+++ b/docs-site/src/content/docs/modules/labeling.md
@@ -4,6 +4,8 @@ description: "Triple-barrier event labeling and metadata generation."
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/microstructural-features.md
+++ b/docs-site/src/content/docs/modules/microstructural-features.md
@@ -1,12 +1,14 @@
 ---
 title: "microstructural_features"
 description: "Price-impact, spread, entropy, and flow toxicity estimators."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "microstructural_features"
+api_surface: "both"
 risk_notes:
   - "Microstructure signals are highly regime-dependent; normalize and standardize within venue/time bucket before cross-asset comparison."
   - "Use shared bar definitions between training and live pipelines, otherwise feature drift is structural."
@@ -101,6 +103,31 @@ assert!(h_plugin.is_finite());
 ```
 
 ## API Reference
+
+### Python API
+
+- `microstructural.get_roll_measure`
+- `microstructural.get_roll_impact`
+- `microstructural.get_corwin_schultz_estimator`
+- `microstructural.get_bekker_parkinson_vol`
+- `microstructural.get_bar_based_kyle_lambda`
+- `microstructural.get_bar_based_amihud_lambda`
+- `microstructural.get_bar_based_hasbrouck_lambda`
+- `microstructural.get_trades_based_kyle_lambda`
+- `microstructural.get_trades_based_amihud_lambda`
+- `microstructural.get_trades_based_hasbrouck_lambda`
+- `microstructural.vwap`
+- `microstructural.get_avg_tick_size`
+- `microstructural.get_vpin`
+- `microstructural.get_bvc_buy_volume`
+- `microstructural.encode_tick_rule_array`
+- `microstructural.quantile_mapping`
+- `microstructural.sigma_mapping`
+- `microstructural.encode_array`
+- `microstructural.get_shannon_entropy`
+- `microstructural.get_lempel_ziv_entropy`
+- `microstructural.get_plug_in_entropy`
+- `microstructural.get_konto_entropy`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/microstructural-features.md
+++ b/docs-site/src/content/docs/modules/microstructural-features.md
@@ -4,6 +4,8 @@ description: "Price-impact, spread, entropy, and flow toxicity estimators."
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/onc.md
+++ b/docs-site/src/content/docs/modules/onc.md
@@ -4,6 +4,8 @@ description: "Optimal Number of Clusters utilities for clustering stability and 
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/onc.md
+++ b/docs-site/src/content/docs/modules/onc.md
@@ -1,12 +1,14 @@
 ---
 title: "onc"
 description: "Optimal Number of Clusters utilities for clustering stability and allocation workflows."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "onc"
+api_surface: "both"
 risk_notes:
   - "Run with repeated seeds/restarts for robust k selection."
   - "Use correlation cleaning before clustering unstable universes."
@@ -50,6 +52,10 @@ println!("{}", out.clusters.len());
 ```
 
 ## API Reference
+
+### Python API
+
+- `onc.get_onc_clusters`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/pipeline.md
+++ b/docs-site/src/content/docs/modules/pipeline.md
@@ -1,13 +1,14 @@
 ---
 title: "pipeline"
 description: "End-to-end AFML research pipeline: events → signals → portfolio → risk → backtest with leakage checks."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "pipeline"
-api_surface: "python-only"
+api_surface: "both"
 risk_notes:
   - "The pipeline enforces input alignment and event ordering as leakage guards."
   - "run_mid_frequency_pipeline_frames adds Polars DataFrames to the raw dict output."
@@ -87,7 +88,7 @@ print(summary)
 - `pipeline.run_mid_frequency_pipeline_frames`
 - `pipeline.summarize_pipeline`
 
-### Key Functions
+### Rust API
 
 - `run_mid_frequency_pipeline`
 - `run_mid_frequency_pipeline_frames`

--- a/docs-site/src/content/docs/modules/pipeline.md
+++ b/docs-site/src/content/docs/modules/pipeline.md
@@ -4,6 +4,8 @@ description: "End-to-end AFML research pipeline: events → signals → portfoli
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/portfolio-optimization.md
+++ b/docs-site/src/content/docs/modules/portfolio-optimization.md
@@ -1,12 +1,14 @@
 ---
 title: "portfolio_optimization"
 description: "Mean-variance and constrained allocation methods with ergonomic APIs."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "portfolio_optimization"
+api_surface: "both"
 risk_notes:
   - "Optimizer output is only as good as mean/covariance assumptions; stress-test inputs and rebalance frequency."
   - "Constraint design (asset caps, sector caps, long/short bounds) is usually more important than small objective tweaks."
@@ -100,6 +102,15 @@ assert!(constrained.weights.iter().all(|w| *w >= -1e-10));
 ```
 
 ## API Reference
+
+### Python API
+
+- `portfolio.allocate_inverse_variance`
+- `portfolio.allocate_min_vol`
+- `portfolio.allocate_max_sharpe`
+- `portfolio.allocate_efficient_risk`
+- `portfolio.allocate_with_solution`
+- `portfolio.allocate_from_inputs`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/portfolio-optimization.md
+++ b/docs-site/src/content/docs/modules/portfolio-optimization.md
@@ -4,6 +4,8 @@ description: "Mean-variance and constrained allocation methods with ergonomic AP
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/research.md
+++ b/docs-site/src/content/docs/modules/research.md
@@ -1,8 +1,9 @@
 ---
 title: "research"
 description: "Synthetic dataset generation and flywheel research iteration with cost modeling and promotion gates."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/research.md
+++ b/docs-site/src/content/docs/modules/research.md
@@ -4,6 +4,8 @@ description: "Synthetic dataset generation and flywheel research iteration with 
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/risk-metrics.md
+++ b/docs-site/src/content/docs/modules/risk-metrics.md
@@ -4,6 +4,8 @@ description: "Portfolio and return-distribution risk measures for downside contr
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/risk-metrics.md
+++ b/docs-site/src/content/docs/modules/risk-metrics.md
@@ -1,12 +1,14 @@
 ---
 title: "risk_metrics"
 description: "Portfolio and return-distribution risk measures for downside control."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "risk_metrics"
+api_surface: "both"
 risk_notes:
   - "Non-parametric estimates need enough tail observations."
   - "Use matrix variants for multi-asset return panels."
@@ -52,6 +54,16 @@ let es95 = RiskMetrics::calculate_expected_shortfall(&r, 0.05)?;
 ```
 
 ## API Reference
+
+### Python API
+
+- `risk.calculate_value_at_risk`
+- `risk.calculate_expected_shortfall`
+- `risk.calculate_conditional_drawdown_risk`
+- `risk.calculate_variance`
+- `risk.calculate_value_at_risk_from_matrix`
+- `risk.calculate_expected_shortfall_from_matrix`
+- `risk.calculate_conditional_drawdown_risk_from_matrix`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/sample-weights.md
+++ b/docs-site/src/content/docs/modules/sample-weights.md
@@ -4,6 +4,8 @@ description: "Sample weighting utilities for overlapping event structure."
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/sample-weights.md
+++ b/docs-site/src/content/docs/modules/sample-weights.md
@@ -1,8 +1,9 @@
 ---
 title: "sample_weights"
 description: "Sample weighting utilities for overlapping event structure."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/sampling.md
+++ b/docs-site/src/content/docs/modules/sampling.md
@@ -1,8 +1,9 @@
 ---
 title: "sampling"
 description: "Indicator matrix and sequential bootstrap tooling."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
@@ -15,11 +16,8 @@ risk_notes:
   - "Use average uniqueness as a diagnostics KPI."
 rust_api:
   - "get_ind_matrix"
-  - "get_ind_mat_average_uniqueness"
-  - "get_ind_mat_label_uniqueness"
-  - "bootstrap_loop_run"
   - "seq_bootstrap"
-  - "get_av_uniqueness_from_triple_barrier"
+  - "get_ind_mat_average_uniqueness"
   - "num_concurrent_events"
 sidebar:
   badge: Module
@@ -110,21 +108,18 @@ let idx = seq_bootstrap(&ind, Some(3), None);
 ### Python API
 
 - `sampling.get_ind_matrix`
+- `sampling.seq_bootstrap`
 - `sampling.get_ind_mat_average_uniqueness`
 - `sampling.get_ind_mat_label_uniqueness`
 - `sampling.bootstrap_loop_run`
-- `sampling.seq_bootstrap`
 - `sampling.get_av_uniqueness_from_triple_barrier`
 - `sampling.num_concurrent_events`
 
 ### Rust API
 
 - `get_ind_matrix`
-- `get_ind_mat_average_uniqueness`
-- `get_ind_mat_label_uniqueness`
-- `bootstrap_loop_run`
 - `seq_bootstrap`
-- `get_av_uniqueness_from_triple_barrier`
+- `get_ind_mat_average_uniqueness`
 - `num_concurrent_events`
 
 ## Implementation Notes

--- a/docs-site/src/content/docs/modules/sampling.md
+++ b/docs-site/src/content/docs/modules/sampling.md
@@ -4,6 +4,8 @@ description: "Indicator matrix and sequential bootstrap tooling."
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/sb-bagging.md
+++ b/docs-site/src/content/docs/modules/sb-bagging.md
@@ -4,6 +4,8 @@ description: "Sequentially bootstrapped bagging classifiers/regressors."
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/sb-bagging.md
+++ b/docs-site/src/content/docs/modules/sb-bagging.md
@@ -1,12 +1,14 @@
 ---
 title: "sb_bagging"
 description: "Sequentially bootstrapped bagging classifiers/regressors."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "sb_bagging"
+api_surface: "both"
 risk_notes:
   - "Sequential bootstrap improves diversity under event overlap."
   - "Tune max_samples/max_features with out-of-sample monitoring."
@@ -50,6 +52,11 @@ let bag = SequentiallyBootstrappedBaggingClassifier::new(100);
 ```
 
 ## API Reference
+
+### Python API
+
+- `sb_bagging.fit_predict_sb_classifier`
+- `sb_bagging.fit_predict_sb_regressor`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/strategy-risk.md
+++ b/docs-site/src/content/docs/modules/strategy-risk.md
@@ -4,6 +4,8 @@ description: "AFML Chapter 15 strategy-viability diagnostics based on precision,
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/strategy-risk.md
+++ b/docs-site/src/content/docs/modules/strategy-risk.md
@@ -1,12 +1,14 @@
 ---
 title: "strategy_risk"
 description: "AFML Chapter 15 strategy-viability diagnostics based on precision, payout asymmetry, and bet frequency."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "strategy_risk"
+api_surface: "both"
 risk_notes:
   - "Inputs under manager control ({pi_minus, pi_plus, n}) should be analyzed separately from uncertain market precision p."
   - "Use this module for strategy-level viability and probability-of-failure diagnostics; use `risk_metrics` for portfolio-tail and drawdown risk."
@@ -73,6 +75,16 @@ println!("failure (KDE): {:.2}%", 100.0 * report.kde_failure_probability);
 ```
 
 ## API Reference
+
+### Python API
+
+- `strategy_risk.sharpe_symmetric`
+- `strategy_risk.implied_precision_symmetric`
+- `strategy_risk.implied_frequency_symmetric`
+- `strategy_risk.sharpe_asymmetric`
+- `strategy_risk.implied_precision_asymmetric`
+- `strategy_risk.implied_frequency_asymmetric`
+- `strategy_risk.estimate_strategy_failure_probability`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/streaming-hpc.md
+++ b/docs-site/src/content/docs/modules/streaming-hpc.md
@@ -1,12 +1,14 @@
 ---
 title: "streaming_hpc"
 description: "AFML Chapter 22 streaming analytics utilities for low-latency early-warning metrics with bounded-memory incremental state."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "streaming_hpc"
+api_surface: "both"
 risk_notes:
   - "Chapter 22 stresses turnaround-time over pure throughput: bounded rolling windows avoid unbounded latency/memory growth."
   - "For low-latency alerts, keep stream partitioning stable and calibrate `mp_batches` against scheduling overhead and cache locality."
@@ -92,6 +94,11 @@ println!("streams={} molecules={} events/s={:.0}",
 ```
 
 ## API Reference
+
+### Python API
+
+- `streaming_hpc.run_streaming_pipeline`
+- `streaming_hpc.generate_synthetic_flash_crash_stream`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/streaming-hpc.md
+++ b/docs-site/src/content/docs/modules/streaming-hpc.md
@@ -4,6 +4,8 @@ description: "AFML Chapter 22 streaming analytics utilities for low-latency earl
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/structural-breaks.md
+++ b/docs-site/src/content/docs/modules/structural-breaks.md
@@ -1,12 +1,14 @@
 ---
 title: "structural_breaks"
 description: "Regime change and bubble diagnostics (Chow, CUSUM variants, SADF)."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "structural_breaks"
+api_surface: "both"
 risk_notes:
   - "SADF can be computationally expensive on long windows."
   - "Use dedicated slow/nightly test paths for heavy scenarios."
@@ -51,6 +53,12 @@ let sadf = get_sadf(&y, 3, SadfLags::Fixed(1))?;
 ```
 
 ## API Reference
+
+### Python API
+
+- `structural_breaks.get_chow_type_stat`
+- `structural_breaks.get_chu_stinchcombe_white_statistics`
+- `structural_breaks.get_sadf`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/structural-breaks.md
+++ b/docs-site/src/content/docs/modules/structural-breaks.md
@@ -4,6 +4,8 @@ description: "Regime change and bubble diagnostics (Chow, CUSUM variants, SADF).
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/synthetic-backtesting.md
+++ b/docs-site/src/content/docs/modules/synthetic-backtesting.md
@@ -1,12 +1,14 @@
 ---
 title: "synthetic_backtesting"
 description: "Synthetic-data OTR backtesting with O-U calibration, PT/SL mesh search, and stability diagnostics."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "synthetic_backtesting"
+api_surface: "both"
 risk_notes:
   - "Near-random-walk estimates (|phi| close to 1) often produce flat Sharpe heatmaps where any selected rule is unstable out-of-sample."
   - "Calibrating to process parameters and evaluating many synthetic paths reduces single-path lucky-fit risk compared to brute-force historical optimization."
@@ -73,6 +75,15 @@ if out.diagnostics.no_stable_optimum {
 ```
 
 ## API Reference
+
+### Python API
+
+- `synthetic_bt.calibrate_ou_params`
+- `synthetic_bt.generate_ou_paths`
+- `synthetic_bt.evaluate_rule_on_paths`
+- `synthetic_bt.detect_no_stable_optimum`
+- `synthetic_bt.run_synthetic_otr_workflow`
+- `synthetic_bt.search_optimal_trading_rule`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/synthetic-backtesting.md
+++ b/docs-site/src/content/docs/modules/synthetic-backtesting.md
@@ -4,6 +4,8 @@ description: "Synthetic-data OTR backtesting with O-U calibration, PT/SL mesh se
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/util-fast-ewma.md
+++ b/docs-site/src/content/docs/modules/util-fast-ewma.md
@@ -1,12 +1,14 @@
 ---
 title: "util::fast_ewma"
 description: "Fast EWMA primitive shared across feature and volatility routines."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "util::fast_ewma"
+api_surface: "both"
 risk_notes:
   - "Window length controls responsiveness vs smoothness."
   - "Prefer this helper over ad-hoc loops for consistency."
@@ -48,6 +50,10 @@ let y = ewma(&x, 3);
 ```
 
 ## API Reference
+
+### Python API
+
+- `fast_ewma.ewma`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/util-fast-ewma.md
+++ b/docs-site/src/content/docs/modules/util-fast-ewma.md
@@ -4,6 +4,8 @@ description: "Fast EWMA primitive shared across feature and volatility routines.
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/util-volatility.md
+++ b/docs-site/src/content/docs/modules/util-volatility.md
@@ -4,6 +4,8 @@ description: "Volatility estimators used across labeling and risk workflows."
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/util-volatility.md
+++ b/docs-site/src/content/docs/modules/util-volatility.md
@@ -1,12 +1,14 @@
 ---
 title: "util::volatility"
 description: "Volatility estimators used across labeling and risk workflows."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "util::volatility"
+api_surface: "both"
 risk_notes:
   - "Choose estimator based on available fields and microstructure noise."
   - "Daily-vol lookback should be matched to event horizon."
@@ -51,6 +53,13 @@ let pv = get_parksinson_vol(&high, &low, 20);
 ```
 
 ## API Reference
+
+### Python API
+
+- `volatility.get_daily_vol`
+- `volatility.get_parksinson_vol`
+- `volatility.get_garman_class_vol`
+- `volatility.get_yang_zhang_vol`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/viz.md
+++ b/docs-site/src/content/docs/modules/viz.md
@@ -1,8 +1,9 @@
 ---
 title: "viz"
 description: "Visualization payload builders for feature importance, drawdown, regime, frontier, and cluster charts."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/viz.md
+++ b/docs-site/src/content/docs/modules/viz.md
@@ -4,6 +4,8 @@ description: "Visualization payload builders for feature importance, drawdown, r
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/quickstart.md
+++ b/docs-site/src/content/docs/quickstart.md
@@ -1,8 +1,8 @@
 ---
 title: Quickstart
 description: Execute the first-run OpenQuant validation path in under 30 minutes.
-status: validated
-last_validated: '2026-03-02'
+status: reviewed
+last_validated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/quickstart.md
+++ b/docs-site/src/content/docs/quickstart.md
@@ -3,6 +3,8 @@ title: Quickstart
 description: Execute the first-run OpenQuant validation path in under 30 minutes.
 status: reviewed
 last_validated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--reviewed">Reviewed</span> A human has read this page end to end. It has not been verified line by line against the code.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/setup/local-build.md
+++ b/docs-site/src/content/docs/setup/local-build.md
@@ -3,6 +3,8 @@ title: Local Build Setup
 description: Deterministic local build and validation sequence.
 status: reviewed
 last_validated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--reviewed">Reviewed</span> A human has read this page end to end. It has not been verified line by line against the code.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/setup/local-build.md
+++ b/docs-site/src/content/docs/setup/local-build.md
@@ -1,8 +1,8 @@
 ---
 title: Local Build Setup
 description: Deterministic local build and validation sequence.
-status: validated
-last_validated: '2026-03-02'
+status: reviewed
+last_validated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/setup/prerequisites.md
+++ b/docs-site/src/content/docs/setup/prerequisites.md
@@ -2,6 +2,8 @@
 title: Prerequisites
 description: Required toolchain and environment assumptions for OpenQuant docs and development.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/setup/prerequisites.md
+++ b/docs-site/src/content/docs/setup/prerequisites.md
@@ -1,8 +1,7 @@
 ---
 title: Prerequisites
 description: Required toolchain and environment assumptions for OpenQuant docs and development.
-status: validated
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/setup/python-bindings.md
+++ b/docs-site/src/content/docs/setup/python-bindings.md
@@ -1,8 +1,7 @@
 ---
 title: Python Bindings Setup
 description: Baseline guidance for Python package workflow integration.
-status: validated
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/setup/python-bindings.md
+++ b/docs-site/src/content/docs/setup/python-bindings.md
@@ -2,6 +2,8 @@
 title: Python Bindings Setup
 description: Baseline guidance for Python package workflow integration.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/setup/troubleshooting.md
+++ b/docs-site/src/content/docs/setup/troubleshooting.md
@@ -1,8 +1,7 @@
 ---
 title: Troubleshooting
 description: Common first-run failures and known fixes.
-status: validated
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/setup/troubleshooting.md
+++ b/docs-site/src/content/docs/setup/troubleshooting.md
@@ -2,6 +2,8 @@
 title: Troubleshooting
 description: Common first-run failures and known fixes.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/workflows/notebook-research-workflow.md
+++ b/docs-site/src/content/docs/workflows/notebook-research-workflow.md
@@ -2,6 +2,8 @@
 title: Notebook Research Workflow
 description: Notebook-first research flow with promotion controls for institutional settings.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/workflows/notebook-research-workflow.md
+++ b/docs-site/src/content/docs/workflows/notebook-research-workflow.md
@@ -1,8 +1,7 @@
 ---
 title: Notebook Research Workflow
 description: Notebook-first research flow with promotion controls for institutional settings.
-status: in_review
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/workflows/python-core-workflow.md
+++ b/docs-site/src/content/docs/workflows/python-core-workflow.md
@@ -2,6 +2,8 @@
 title: Python Core Workflow
 description: Python-first workflow for ingestion, bars, diagnostics, and mid-frequency pipeline execution.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/workflows/python-core-workflow.md
+++ b/docs-site/src/content/docs/workflows/python-core-workflow.md
@@ -1,8 +1,7 @@
 ---
 title: Python Core Workflow
 description: Python-first workflow for ingestion, bars, diagnostics, and mid-frequency pipeline execution.
-status: validated
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/workflows/rust-core-workflow.md
+++ b/docs-site/src/content/docs/workflows/rust-core-workflow.md
@@ -2,6 +2,8 @@
 title: Rust Core Workflow
 description: Canonical Rust workflow from event sampling to portfolio/risk diagnostics.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/workflows/rust-core-workflow.md
+++ b/docs-site/src/content/docs/workflows/rust-core-workflow.md
@@ -1,8 +1,7 @@
 ---
 title: Rust Core Workflow
 description: Canonical Rust workflow from event sampling to portfolio/risk diagnostics.
-status: validated
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/styles/starlight.css
+++ b/docs-site/src/styles/starlight.css
@@ -229,3 +229,16 @@ h1 {
   font-family: var(--sl-font-mono);
   font-size: 0.92em;
 }
+
+/* The landing page shares its banner between the status badge and a call to
+   action, so links there take the status colours rather than the gradient
+   banner's near-white. */
+.sl-banner:has(.doc-status) a {
+  color: var(--doc-status-fg) !important;
+  text-decoration: underline !important;
+  text-underline-offset: 0.2em;
+}
+
+.sl-banner:has(.doc-status) a:hover {
+  color: var(--doc-status-pill) !important;
+}

--- a/docs-site/src/styles/starlight.css
+++ b/docs-site/src/styles/starlight.css
@@ -145,3 +145,87 @@ h1 {
 .pagination-links a {
   border-radius: 10px;
 }
+
+/* ── Page status badge ───────────────────────────────────────────────────────
+   Every doc page declares a `status` in its frontmatter and renders it through
+   the Starlight banner slot, so a reader can always tell whether a page was
+   machine-generated, is an unfinished draft, or has actually been read by a
+   human. Wired through `banner.content` rather than a Starlight component
+   override, because an override has to be registered in astro.config.mjs and
+   this branch does not own that file. check-content-schema.mjs enforces that
+   the badge matches the frontmatter status, so the two cannot drift.
+   The `:has()` guard keeps the site-wide banner gradient above intact for any
+   non-status banner. */
+.sl-banner:has(.doc-status) {
+  background: var(--doc-status-bg) !important;
+  color: var(--doc-status-fg) !important;
+  border-bottom: 1px solid var(--doc-status-border) !important;
+  font-size: var(--sl-text-sm);
+  font-weight: 500;
+  text-wrap: balance;
+}
+
+.sl-banner:has(.doc-status--generated) {
+  --doc-status-bg: #e7edf5;
+  --doc-status-fg: #2c3f55;
+  --doc-status-border: #c9d8e8;
+  --doc-status-pill: #5c728c;
+}
+
+.sl-banner:has(.doc-status--draft) {
+  --doc-status-bg: #fdf1dc;
+  --doc-status-fg: #5a4209;
+  --doc-status-border: #ecd39a;
+  --doc-status-pill: #a8760d;
+}
+
+.sl-banner:has(.doc-status--reviewed) {
+  --doc-status-bg: #e3f1e7;
+  --doc-status-fg: #1d4429;
+  --doc-status-border: #b7ddc3;
+  --doc-status-pill: #2f7d4a;
+}
+
+:root[data-theme='dark'] .sl-banner:has(.doc-status--generated) {
+  --doc-status-bg: #1a2536;
+  --doc-status-fg: #c3d3e6;
+  --doc-status-border: #294156;
+  --doc-status-pill: #55708f;
+}
+
+:root[data-theme='dark'] .sl-banner:has(.doc-status--draft) {
+  --doc-status-bg: #2e2716;
+  --doc-status-fg: #ecd7a4;
+  --doc-status-border: #4d3f1d;
+  --doc-status-pill: #a8790f;
+}
+
+:root[data-theme='dark'] .sl-banner:has(.doc-status--reviewed) {
+  --doc-status-bg: #16301f;
+  --doc-status-fg: #b9dcc5;
+  --doc-status-border: #27563a;
+  --doc-status-pill: #2f7d4a;
+}
+
+.doc-status {
+  display: inline-block;
+  margin-right: 0.5rem;
+  padding: 0.08rem 0.55rem;
+  border-radius: 999px;
+  background: var(--doc-status-pill);
+  color: #ffffff;
+  font-family: var(--sl-font-mono);
+  font-size: 0.72em;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  vertical-align: 0.1em;
+}
+
+.sl-banner:has(.doc-status) code {
+  padding: 0.05rem 0.3rem;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--doc-status-fg) 12%, transparent);
+  font-family: var(--sl-font-mono);
+  font-size: 0.92em;
+}


### PR DESCRIPTION
## Why

Every page on the docs site claimed it had been reviewed. None of them had been.

`status: validated` and `last_validated: '2026-03-02'` were **hardcoded string literals** in
`docs-site/scripts/generate-module-doc-pages.mjs`. The generator consulted no reviewer, no date and
no git history — it re-stamped the same claim on every run. All 59 pages carried the identical
review date, and 56 asserted `validated`.

The gate that supposedly enforced this only checked that the *keys existed and were non-empty*.
`status: banana` would have passed. So a green "content schema check passed (59 docs files)"
certified nothing at all.

## The taxonomy

Four values, each claiming strictly more human attention than the last, each tied to the date field
that can actually back it:

| Status | Meaning | Date field |
|---|---|---|
| `generated` | Machine-emitted from `moduleDocs.ts`. Nobody has read it. | `last_generated` |
| `draft` | Hand-written, known incomplete. Claims nothing. | *none permitted* |
| `reviewed` | A human read the page and it stands. | `last_validated` |
| `validated` | Reviewed **and** checked against the code it describes. | `last_validated` |

Two deliberate choices worth calling out:

- **`draft` may not carry a date at all**, and the gate rejects one. A weaker date on an unreviewed
  page is still a claim; the honest move is to make none.
- **`validated` is currently used by zero pages, by design.** Nothing in this pass earned it. It
  stays in the enum as the target state, reachable only by someone who does that work.

## What changed

| Commit | Change |
|---|---|
| `5ff9838` | Generator emits `status: generated` + `last_generated` (date-only, so repeat runs stay byte-identical) instead of asserting validation |
| `aa8d5fe` | Schema gate enforces **values**: the enum, real ISO dates, correct status/date pairing, and a freshness rule |
| `c915df4` | The 19 hand-written pages get honest statuses — 6 `reviewed`, 13 `draft` |
| `bb6614c` | `status` rendered to readers as a coloured badge with a one-line explanation |
| `17c6495` | Align `src/content/config.ts` — it carried its **own** third, independent status enum that matched neither the generator nor the gate |

### The freshness rule

A page fails when its last actual change is newer than the date it claims. "Last change" is the
newer of the git commit date and, for dirty or untracked files, the filesystem mtime — so
uncommitted edits count. This is what makes the stamp unforgeable.

**It caught a real defect on its first run:** `index.md` failed with *"page last changed 2026-03-03
but claims `last_validated: '2026-03-02'`"*. That page had been edited the day **after** its own
stamped review date and had been shipping as `validated` ever since. The old gate could not see it.

## Result

| | Before | After |
|---|---|---|
| `status: validated` | 56 pages | **0** |
| `last_validated: '2026-03-02'` | 59 pages | **0** |
| `generated` / `draft` / `reviewed` | — | 40 / 13 / 6 |
| Status visible to a reader | nowhere | 58 pages |

## Verification

- `astro build` → 0 (99 pages) · `check-content-schema` → 0
  (*"59 docs files: 40 generated, 13 draft, 6 reviewed"*)
- **Generator is idempotent** — run twice, zero tracked changes
- **The gate was proven to bite**, each fault injected then reverted: bogus status → exit 1;
  date behind the page's last change → exit 1; impossible date `2026-02-31` → exit 1;
  badge disagreeing with frontmatter → exit 1; `draft` carrying a date → exit 1

Failure messages offer the honest option first — *"if you have not re-read it, lower the status to
`draft` instead of bumping the date."*

## Known limitations

- **The badge uses the frontmatter `banner` slot, not a Starlight component override.** The
  idiomatic approach needs a `components:` entry in `astro.config.mjs`, which this branch was scoped
  not to touch (a sibling PR owns that file). It works and is fully visible, but it is the
  second-best mechanism: the badge currently sits *beside* the status rather than being derived
  *from* it. The gate therefore also fails when the two disagree, so they cannot drift. Worth
  converting later — a one-line `components` entry plus a small `.astro` component.
- **58 of 59 pages show a badge.** The 59th is `modules/index.md`, currently unreachable because a
  `/modules` redirect shadows it; #17 fixes that, after which it renders too.
- **The `reviewed` split is 6, not the 13 quoted in the audit's summary table.** That table is
  inconsistent with its own per-page inventory, which marks 3 pages solid and 4 thin against 13
  stub/redundant. This PR follows the inventory — the conservative direction, and the point of the
  exercise. Promoting 7 more pages should follow someone actually reading them.
- Content quality itself (thin pages, non-compiling Rust examples, IA) is **not** addressed here.
