### PR TITLE
docs: make the eight setup and workflow pages deliver on their titles

### DIFF
--- a/docs-site/scripts/check-content-schema.mjs
+++ b/docs-site/scripts/check-content-schema.mjs
@@ -1,7 +1,30 @@
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
 const docsRoot = path.resolve(process.cwd(), 'src/content/docs');
+
+/**
+ * The status taxonomy. The ordering is deliberate: each value claims strictly
+ * more human attention than the one before it.
+ *
+ *   generated — machine-emitted from src/data/moduleDocs.ts. Nobody has read it.
+ *   draft     — hand-written, known to be incomplete. Claims nothing.
+ *   reviewed  — a human read the page and it stands on its own.
+ *   validated — reviewed AND checked against the code it describes.
+ *
+ * Each status names the date field that backs it. `draft` and `generated` cannot
+ * claim `last_validated`, because neither has been validated by anyone — that is
+ * the whole point of the taxonomy, and the gate below enforces it.
+ */
+const STATUS_DATE_FIELD = {
+  generated: 'last_generated',
+  draft: null,
+  reviewed: 'last_validated',
+  validated: 'last_validated',
+};
+const STATUSES = Object.keys(STATUS_DATE_FIELD);
+const DATE_FIELDS = ['last_generated', 'last_validated'];
 
 function walk(dir) {
   const files = [];
@@ -26,29 +49,171 @@ function parseFrontmatter(text) {
   for (const line of raw.split('\n')) {
     if (!line.trim() || line.trim().startsWith('#')) continue;
     const kv = line.match(/^([A-Za-z_][A-Za-z0-9_]*):\s*(.*)$/);
-    if (kv) out[kv[1]] = kv[2];
+    if (kv) out[kv[1]] = unquote(kv[2]);
   }
   return out;
 }
 
+function unquote(value) {
+  const v = String(value).trim();
+  if (v.length >= 2 && (v[0] === "'" || v[0] === '"') && v.at(-1) === v[0]) {
+    return v.slice(1, -1);
+  }
+  return v;
+}
+
+/** A real YYYY-MM-DD date, not merely a string shaped like one (2026-02-31 is not a date). */
+function parseIsoDate(value) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+  const d = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString().slice(0, 10) === value ? d : null;
+}
+
+function git(args, cwd) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+/**
+ * Last date each doc actually changed — the newer of its last commit date and,
+ * when the working tree copy differs from HEAD (or is untracked), its filesystem
+ * mtime. Uncommitted edits count: otherwise you could edit a page and keep a
+ * stale stamp green right up until the moment you commit.
+ *
+ * Returns a Map of absolute path -> YYYY-MM-DD, or null if this is not a git
+ * checkout (in which case freshness is checked against mtime alone).
+ */
+function lastChangedDates(files) {
+  const dates = new Map();
+  const mtimeDay = (file) => fs.statSync(file).mtime.toISOString().slice(0, 10);
+
+  let repoRoot;
+  try {
+    repoRoot = git(['rev-parse', '--show-toplevel'], docsRoot).trim();
+  } catch {
+    // Not a git checkout (a release tarball, say). Fall back to mtime for everything.
+    for (const file of files) dates.set(file, mtimeDay(file));
+    return dates;
+  }
+
+  // One `git log` walk over the whole docs tree rather than one subprocess per
+  // file. Commits are newest-first, so the first time a path appears is its most
+  // recent change.
+  const log = git(
+    ['log', '--pretty=format:%x00%cI', '--name-only', '--diff-filter=d', '--', docsRoot],
+    repoRoot
+  );
+  let commitDay = null;
+  for (const line of log.split('\n')) {
+    if (line.startsWith('\0')) {
+      commitDay = line.slice(1, 11);
+      continue;
+    }
+    if (!line.trim() || !commitDay) continue;
+    const abs = path.resolve(repoRoot, line.trim());
+    if (!dates.has(abs)) dates.set(abs, commitDay);
+  }
+
+  // Anything modified or untracked in the working tree is at least as new as its mtime.
+  const status = git(['status', '--porcelain', '--', docsRoot], repoRoot);
+  for (const line of status.split('\n')) {
+    if (!line.trim()) continue;
+    const rel = line.slice(3).split(' -> ').at(-1).replace(/^"|"$/g, '');
+    const abs = path.resolve(repoRoot, rel);
+    if (!fs.existsSync(abs) || fs.statSync(abs).isDirectory()) continue;
+    const day = mtimeDay(abs);
+    if (!dates.has(abs) || day > dates.get(abs)) dates.set(abs, day);
+  }
+
+  for (const file of files) {
+    if (!dates.has(file)) dates.set(file, mtimeDay(file));
+  }
+  return dates;
+}
+
 const files = walk(docsRoot);
-const missing = [];
+const changed = lastChangedDates(files);
+const errors = [];
 
 for (const file of files) {
-  const text = fs.readFileSync(file, 'utf8');
-  const fm = parseFrontmatter(text);
-  const required = ['title', 'description', 'status', 'last_validated'];
-  for (const key of required) {
-    if (!(key in fm) || String(fm[key]).trim() === '') {
-      missing.push(`${path.relative(process.cwd(), file)} missing ${key}`);
+  const rel = path.relative(process.cwd(), file);
+  const fm = parseFrontmatter(fs.readFileSync(file, 'utf8'));
+  const fail = (msg) => errors.push(`${rel}: ${msg}`);
+
+  for (const key of ['title', 'description', 'status']) {
+    if (!(key in fm) || fm[key].trim() === '') fail(`missing ${key}`);
+  }
+
+  const status = fm.status;
+  if (status === undefined || status.trim() === '') continue;
+
+  if (!STATUSES.includes(status)) {
+    fail(
+      `status: ${status} is not one of ${STATUSES.join(' | ')}. ` +
+        `Use 'generated' for machine-emitted pages, 'draft' for hand-written pages ` +
+        `that are not finished, 'reviewed' once a human has read the page, and ` +
+        `'validated' once it has also been checked against the code.`
+    );
+    continue;
+  }
+
+  // Every date present must be a real ISO date, whether or not this status needs it.
+  for (const field of DATE_FIELDS) {
+    if (field in fm && !parseIsoDate(fm[field])) {
+      fail(`${field}: ${fm[field]} is not a valid ISO date (expected YYYY-MM-DD)`);
     }
+  }
+
+  const dateField = STATUS_DATE_FIELD[status];
+  if (dateField === null) {
+    if ('last_validated' in fm) {
+      fail(
+        `status: draft must not carry last_validated — a draft has not been ` +
+          `validated by anyone. Drop the field, or raise the status to 'reviewed'.`
+      );
+    }
+    continue;
+  }
+
+  if (!(dateField in fm) || fm[dateField].trim() === '') {
+    fail(`status: ${status} requires ${dateField} (YYYY-MM-DD)`);
+    continue;
+  }
+
+  const stamped = parseIsoDate(fm[dateField]);
+  if (!stamped) continue; // already reported above
+
+  // The rule that makes the stamp mean something: a page cannot claim to have
+  // been reviewed or generated BEFORE the last time its content actually changed.
+  // Without this, `status: validated` is just a string anyone can paste, and can
+  // be bulk-applied to a whole corpus — which is exactly how this site ended up
+  // with 59 pages sharing one hardcoded review date.
+  const changedOn = changed.get(file);
+  if (changedOn && changedOn > fm[dateField]) {
+    const what =
+      status === 'generated'
+        ? `Re-run 'node scripts/generate-module-doc-pages.mjs' to re-stamp it`
+        : `Re-read the page; if it still stands, set ${dateField}: '${changedOn}'. ` +
+          `If you have not re-read it, lower the status to 'draft' instead of ` +
+          `bumping the date`;
+    fail(
+      `stale ${dateField}: page last changed ${changedOn} but claims ` +
+        `${dateField}: '${fm[dateField]}'. The content moved after the ` +
+        `stamp, so the stamp no longer describes this page. ${what}.`
+    );
   }
 }
 
-if (missing.length) {
-  console.error('Content schema check failed:');
-  for (const err of missing) console.error(`- ${err}`);
+if (errors.length) {
+  console.error(`Content schema check FAILED (${errors.length} problem(s)):`);
+  for (const err of errors) console.error(`- ${err}`);
   process.exit(1);
 }
 
-console.log(`Content schema check passed (${files.length} docs files).`);
+const tally = {};
+for (const file of files) {
+  const s = parseFrontmatter(fs.readFileSync(file, 'utf8')).status ?? '(none)';
+  tally[s] = (tally[s] ?? 0) + 1;
+}
+const summary = STATUSES.filter((s) => tally[s]).map((s) => `${tally[s]} ${s}`).join(', ');
+console.log(`Content schema check passed (${files.length} docs files: ${summary}).`);

--- a/docs-site/scripts/check-content-schema.mjs
+++ b/docs-site/scripts/check-content-schema.mjs
@@ -80,8 +80,8 @@ function git(args, cwd) {
  * mtime. Uncommitted edits count: otherwise you could edit a page and keep a
  * stale stamp green right up until the moment you commit.
  *
- * Returns a Map of absolute path -> YYYY-MM-DD, or null if this is not a git
- * checkout (in which case freshness is checked against mtime alone).
+ * Returns a Map of absolute path -> YYYY-MM-DD. Outside a git checkout (a release
+ * tarball, say) freshness falls back to mtime alone.
  */
 function lastChangedDates(files) {
   const dates = new Map();
@@ -137,7 +137,9 @@ const errors = [];
 
 for (const file of files) {
   const rel = path.relative(process.cwd(), file);
-  const fm = parseFrontmatter(fs.readFileSync(file, 'utf8'));
+  const text = fs.readFileSync(file, 'utf8');
+  const frontmatter = text.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? '';
+  const fm = parseFrontmatter(text);
   const fail = (msg) => errors.push(`${rel}: ${msg}`);
 
   for (const key of ['title', 'description', 'status']) {
@@ -155,6 +157,16 @@ for (const file of files) {
         `'validated' once it has also been checked against the code.`
     );
     continue;
+  }
+
+  // The reader-facing badge is rendered from the page's own banner frontmatter,
+  // so it can drift from `status` unless something checks. This is that check.
+  const badge = frontmatter.match(/doc-status--([a-z]+)/)?.[1];
+  if (badge && badge !== status) {
+    fail(
+      `status: ${status} but the reader-facing badge says '${badge}'. ` +
+        `Update the banner content so the badge matches the frontmatter status.`
+    );
   }
 
   // Every date present must be a real ISO date, whether or not this status needs it.

--- a/docs-site/scripts/generate-module-doc-pages.mjs
+++ b/docs-site/scripts/generate-module-doc-pages.mjs
@@ -155,6 +155,8 @@ description: ${q(doc.summary)}
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '${generatedOn}'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering
@@ -201,6 +203,8 @@ description: "Full OpenQuant module documentation index with AFML-aligned summar
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '${generatedOn}'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/scripts/generate-module-doc-pages.mjs
+++ b/docs-site/scripts/generate-module-doc-pages.mjs
@@ -5,6 +5,13 @@ import { moduleDocs } from '../src/data/moduleDocs.ts';
 const outDir = path.resolve(process.cwd(), 'src/content/docs/modules');
 fs.mkdirSync(outDir, { recursive: true });
 
+// These pages are machine-emitted from src/data/moduleDocs.ts and have not been read
+// by a human, so they may only ever claim 'generated' — never 'reviewed' or 'validated'.
+// Those stronger statuses are reachable only by a person deliberately editing a page.
+// Date-only, so repeated runs on the same day are byte-identical (the generator must
+// stay idempotent) and so the stamp is comparable with the schema gate's mtime rule.
+const generatedOn = new Date().toISOString().slice(0, 10);
+
 const q = (value) => JSON.stringify(String(value));
 const toYamlList = (values) => values.map((v) => `  - ${q(v)}`).join('\n');
 
@@ -145,8 +152,9 @@ for (const doc of moduleDocs) {
   const content = `---
 title: ${q(doc.module)}
 description: ${q(doc.summary)}
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '${generatedOn}'
 audience:
   - quant-dev
   - platform-engineering
@@ -190,8 +198,9 @@ const groupedIndex = [...bySubject.entries()]
 const indexContent = `---
 title: "Module Reference Index"
 description: "Full OpenQuant module documentation index with AFML-aligned summaries."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '${generatedOn}'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/config.ts
+++ b/docs-site/src/content/config.ts
@@ -5,7 +5,13 @@ const docs = defineCollection({
   schema: docsSchema({
     extend: z.object({
       audience: z.array(z.string()).optional(),
-      status: z.enum(['draft', 'in_review', 'validated']).optional(),
+      // Kept in step with STATUS_DATE_FIELD in scripts/check-content-schema.mjs,
+      // which additionally enforces that the date backing a status is real and is
+      // not older than the page's last change. Required, not optional: a page with
+      // no status is a page making an unexamined claim by omission.
+      status: z.enum(['generated', 'draft', 'reviewed', 'validated']),
+      last_generated: z.string().optional(),
+      generated_from: z.string().optional(),
       last_validated: z.string().optional(),
       module: z.string().optional(),
       afml_chapter: z.array(z.string()).optional(),

--- a/docs-site/src/content/docs/coverage.md
+++ b/docs-site/src/content/docs/coverage.md
@@ -1,8 +1,7 @@
 ---
 title: Coverage Dashboard
 description: AFML-aligned documentation coverage checkpoints and current completeness status.
-status: validated
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/coverage.md
+++ b/docs-site/src/content/docs/coverage.md
@@ -2,6 +2,8 @@
 title: Coverage Dashboard
 description: AFML-aligned documentation coverage checkpoints and current completeness status.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/coverage.md
+++ b/docs-site/src/content/docs/coverage.md
@@ -1,6 +1,6 @@
 ---
 title: Coverage Dashboard
-description: AFML-aligned documentation coverage checkpoints and current completeness status.
+description: What is documented, what is not, and the commands that produce those numbers.
 status: draft
 banner:
   content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
@@ -11,14 +11,105 @@ sidebar:
   order: 90
 ---
 
-## Coverage Focus Areas
+Every number on this page comes with the command that produced it. Run the
+command; if the answer differs, the page is out of date and the command is
+right. A coverage page maintained any other way tells you what someone
+hoped was true on the day they wrote it.
 
-- Core workflow docs are complete for setup, Rust, Python, and governance baselines.
-- Module reference pages are generated for all currently indexed modules.
-- AFML chapter mapping is provided in [By AFML Chapter](/module-reference/by-afml-chapter/).
+Numbers below were measured on **2026-08-30**.
 
-## Current Gaps
+## Documentation status
 
-- Some governance pages remain baseline-level and require deeper institutional control details.
-- Examples need expansion from baseline snippets to complete end-to-end case studies.
-- Module parity depth (Rust/Python narrative parity) remains an active workstream.
+```bash
+cd docs-site && node scripts/check-content-schema.mjs
+```
+
+That gate runs in CI and prints a tally of every page by `status`. As of
+the date above:
+
+| `status` | Pages | Means |
+|---|---|---|
+| `generated` | 40 | Emitted from `src/data/moduleDocs.ts`. Nobody has read it. |
+| `draft` | 8 | Hand-written, known incomplete. Claims nothing. |
+| `reviewed` | 11 | A human read the page end to end. |
+| `validated` | 0 | Reviewed *and* checked against the code. Nothing has earned this yet. |
+| **Total** | **59** | |
+
+The headline number is the last row of that table: **no page on this site
+is `validated`.** Until recently every page claimed `status: validated`
+with an identical `last_validated` date, because the value was a string
+literal in the page generator rather than a record of anyone's review.
+The taxonomy in `docs-site/scripts/check-content-schema.mjs` now refuses
+a stamp that predates the page's last content change, so the tally above
+cannot be bulk-applied.
+
+## Module documentation depth
+
+```bash
+cd docs-site
+grep -c '^    module:' src/data/moduleDocs.ts          # documented modules
+grep -c '^    conceptOverview:' src/data/moduleDocs.ts # of those, the enriched tier
+```
+
+| | Count |
+|---|---|
+| Modules with a documentation entry | 39 |
+| …of which get the **enriched** template (`conceptOverview`, `whenToUse`, `keyParameters`, `commonPitfalls`, `relatedModules`) | 12 |
+| …of which fall through to the **stub** template (`Subject` + one sentence per heading) | 27 |
+
+The stub tier is 69% of the module pages. Those pages have a heading
+skeleton, one sentence under each heading, and a closing "Implementation
+Notes" section that is a verbatim reprint of the page's own `risk_notes`
+frontmatter. Depth on those pages is a generator problem, not a per-page
+problem: adding `conceptOverview` to an entry in `moduleDocs.ts` moves it
+to the enriched tier.
+
+## Code with no documentation entry at all
+
+```bash
+docd=$(grep -o 'module: "[^"]*"' docs-site/src/data/moduleDocs.ts | sed 's/module: "//;s/"//' | sort)
+comm -13 <(echo "$docd") <(grep "^pub mod" crates/openquant/src/lib.rs | sed 's/pub mod //;s/;//' | sort)
+comm -13 <(echo "$docd") <(ls python/openquant/*.py | xargs -n1 basename | sed 's/\.py//' | grep -v __init__ | sort)
+```
+
+| Surface | Undocumented |
+|---|---|
+| Rust (`crates/openquant/src/lib.rs`) | `data_processing` |
+| Python (`python/openquant/`) | `bars` |
+
+`util` also appears in the raw diff, but it is a parent module whose two
+children (`util::fast_ewma`, `util::volatility`) both have pages; it is
+not a gap.
+
+`openquant.bars` is the sharper miss of the two. It has no module page
+even though [Python Core Workflow](/workflows/python-core-workflow/)
+makes it a whole stage, and its memory behaviour under large inputs is
+non-obvious enough to have earned an entry in
+[Troubleshooting](/setup/troubleshooting/#python-runs-out-of-memory-building-bars-from-a-large-dataset).
+
+## What this page does not measure
+
+Honestly: most of what you would want.
+
+- **Prose quality.** `status` records whether a human read a page, not
+  whether the page is good.
+- **Whether the examples run.** Nothing in CI executes the code blocks on
+  these pages. The commands on the setup pages were executed by hand; the
+  module pages' snippets were not, and several of them do not compile.
+- **API parity between Rust and Python.** `check:api-drift`
+  (`scripts/generate_api_inventory.py --check`) tracks the *inventory* of
+  public symbols, not whether both surfaces are documented equivalently.
+  That gate is **currently failing** on this branch.
+
+:::note[Why this page is still `draft`]
+Three of the four tables above are hand-transcribed from commands run
+once, on one day. That is better than the prose bullets this page used to
+carry, and every figure can be re-derived in seconds — but it is still a
+snapshot a human has to refresh, which is exactly the failure mode the
+page warns about in its first paragraph.
+
+The fix is to emit this page from the gate that already computes the
+tally. `check-content-schema.mjs` builds the status counts on every run
+and throws them away after printing. Until it writes them out instead,
+this page stays `draft`.
+:::

--- a/docs-site/src/content/docs/examples/catalog.md
+++ b/docs-site/src/content/docs/examples/catalog.md
@@ -2,6 +2,8 @@
 title: Examples Catalog
 description: Example entry points grouped by workflow stage.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/examples/catalog.md
+++ b/docs-site/src/content/docs/examples/catalog.md
@@ -1,6 +1,6 @@
 ---
 title: Examples Catalog
-description: Example entry points grouped by workflow stage.
+description: Runnable examples that ship in this repository, and what each one demonstrates.
 status: draft
 banner:
   content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
@@ -11,17 +11,95 @@ sidebar:
   order: 1
 ---
 
-## Setup and validation
+Every example below is a file in this repository that you can execute. The
+point of this page is that you should not have to trust a snippet: each
+entry names the file, the command that runs it, and what it demonstrates.
 
-- [Quickstart](/quickstart/)
-- [Local Build Setup](/setup/local-build/)
+All of them need the Python bindings built first — see
+[Python Bindings Setup](/setup/python-bindings/). The Rust example needs
+only `cargo`.
 
-## Research workflows
+## Examples that ship in the repo
 
-- [Rust Core Workflow](/workflows/rust-core-workflow/)
-- [Python Core Workflow](/workflows/python-core-workflow/)
-- [Notebook Research Workflow](/workflows/notebook-research-workflow/)
+| File | Run it with | Demonstrates |
+|---|---|---|
+| `crates/openquant/examples/research_notebook_smoke.rs` | `cargo run -p openquant --example research_notebook_smoke` | The minimum Rust path: CUSUM event sampling → max-Sharpe allocation → VaR/ES/CDaR. ~30 lines, asserts its own invariants. |
+| `notebooks/python/scripts/smoke_all.py` | `just notebook-smoke` | Executes all eight research notebooks headlessly. The broadest single check that the Python surface works. |
+| `experiments/run_pipeline.py` | `just exp-run` | A config-driven pipeline run (`experiments/configs/futures_oil_baseline.toml`) that writes artifacts to `experiments/artifacts`. |
+| `python/benchmarks/benchmark_pipeline.py` | `just py-bench` | Times the mid-frequency pipeline over 30 iterations at 2048 bars. |
+| `python/benchmarks/benchmark_data_processing.py` | `just py-bench-data` | Ingestion and bar-building throughput at 200k rows × 4 symbols. Use this if you want a real memory profile before feeding it production data. |
+| `python/tests/` | `just py-test` | Nine test modules that double as usage examples — `test_pipeline_api.py` and `test_bindings_contract.py` are the two worth reading first. |
 
-## Module examples
+The eight notebooks under `notebooks/python/` are numbered in reading
+order, from `01_event_labeling_and_pipeline.ipynb` to
+`08_algo_wheel_experiments.ipynb`, and
+`06_afml_real_data_end_to_end.ipynb` is the one that runs on real data
+rather than synthetic.
 
-- [Module Pages](/module/)
+## Worked example: cleaning a messy OHLCV file
+
+The repository ships a deliberately awful CSV at
+`python/tests/fixtures/ohlcv_us_equities.csv` — non-canonical column
+names, two symbols interleaved, rows out of chronological order, and a
+duplicated `2024-01-02` bar for AAPL:
+
+```
+Date,Ticker,Open,High,Low,Close,Volume,Adj Close
+2024-01-03,AAPL,186.10,187.00,185.50,186.30,5000,186.10
+2024-01-01,AAPL,184.00,185.00,183.50,184.80,8000,184.70
+2024-01-02,AAPL,185.00,186.20,184.70,185.90,7000,185.80
+2024-01-02,AAPL,185.05,186.30,184.60,186.00,7100,185.90
+2024-01-01,MSFT,370.10,372.00,369.90,371.50,6000,371.30
+2024-01-03,MSFT,372.20,373.10,371.40,372.00,5500,371.90
+```
+
+`load_ohlcv` canonicalises the header (`Date` → `ts`, `Ticker` →
+`symbol`, `Adj Close` → `adj_close`), sorts by symbol and timestamp, and
+drops the duplicate — keeping the *last* occurrence by default, which is
+the convention you want when a vendor restates a bar:
+
+```python
+from openquant import data
+
+frame, report = data.load_ohlcv(
+    "python/tests/fixtures/ohlcv_us_equities.csv",
+    return_report=True,
+)
+print(frame)
+print(report)
+```
+
+Ask for the report whenever the data is not yours. Silent deduplication
+is how a survivorship or restatement bug gets into a backtest without
+anyone noticing.
+
+## Worked example: the whole research loop
+
+The end-to-end loops are long enough to deserve their own pages, with the
+stages explained rather than just listed:
+
+- [Rust Core Workflow](/workflows/rust-core-workflow/) — one program: event
+  sampling → triple-barrier labels → bet sizing → purged CV → risk and
+  allocation, with its printed output.
+- [Python Core Workflow](/workflows/python-core-workflow/) — the same
+  ground in Python, ending in a promotion decision.
+- [Notebook Research Workflow](/workflows/notebook-research-workflow/) —
+  the notebook-driven version.
+
+## Where to start
+
+| If you want to… | Go here |
+|---|---|
+| See OpenQuant produce a number, once | [Quickstart](/quickstart/) |
+| Understand the Rust API | [Rust Core Workflow](/workflows/rust-core-workflow/) |
+| Understand the Python API | [Python Core Workflow](/workflows/python-core-workflow/) |
+| Look up one module | [Modules by AFML chapter](/module-reference/by-afml-chapter/) |
+| Build and test the repo | [Local Build Setup](/setup/local-build/) |
+
+:::note[What is still missing]
+This page indexes examples and works two of them. It does not yet have a
+worked example for feature diagnostics (MDI/MDA/SFI and the substitution
+effect), which is the part of the library most likely to be misused, nor
+one for `backtesting_engine`'s CPCV path. That is why this page is still
+`draft`.
+:::

--- a/docs-site/src/content/docs/examples/catalog.md
+++ b/docs-site/src/content/docs/examples/catalog.md
@@ -1,8 +1,7 @@
 ---
 title: Examples Catalog
 description: Example entry points grouped by workflow stage.
-status: in_review
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/governance/benchmark-policy.md
+++ b/docs-site/src/content/docs/governance/benchmark-policy.md
@@ -2,6 +2,8 @@
 title: Benchmark Policy
 description: Performance benchmarking and regression guardrails.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/governance/benchmark-policy.md
+++ b/docs-site/src/content/docs/governance/benchmark-policy.md
@@ -1,8 +1,7 @@
 ---
 title: Benchmark Policy
 description: Performance benchmarking and regression guardrails.
-status: validated
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/governance/methodology-and-leakage-controls.md
+++ b/docs-site/src/content/docs/governance/methodology-and-leakage-controls.md
@@ -3,6 +3,8 @@ title: Methodology and Leakage Controls
 description: Required anti-leakage and methodology controls for OpenQuant research and evaluation.
 status: reviewed
 last_validated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--reviewed">Reviewed</span> A human has read this page end to end. It has not been verified line by line against the code.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/governance/methodology-and-leakage-controls.md
+++ b/docs-site/src/content/docs/governance/methodology-and-leakage-controls.md
@@ -1,8 +1,8 @@
 ---
 title: Methodology and Leakage Controls
 description: Required anti-leakage and methodology controls for OpenQuant research and evaluation.
-status: validated
-last_validated: '2026-03-02'
+status: reviewed
+last_validated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/governance/reproducibility-and-artifact-contracts.md
+++ b/docs-site/src/content/docs/governance/reproducibility-and-artifact-contracts.md
@@ -1,8 +1,8 @@
 ---
 title: Reproducibility and Artifact Contracts
 description: Minimum artifact and metadata contract for reproducible research outcomes.
-status: validated
-last_validated: '2026-03-02'
+status: reviewed
+last_validated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/governance/reproducibility-and-artifact-contracts.md
+++ b/docs-site/src/content/docs/governance/reproducibility-and-artifact-contracts.md
@@ -3,6 +3,8 @@ title: Reproducibility and Artifact Contracts
 description: Minimum artifact and metadata contract for reproducible research outcomes.
 status: reviewed
 last_validated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--reviewed">Reviewed</span> A human has read this page end to end. It has not been verified line by line against the code.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/governance/support-and-escalation.md
+++ b/docs-site/src/content/docs/governance/support-and-escalation.md
@@ -2,6 +2,8 @@
 title: Support and Escalation
 description: Operational support entry points and escalation expectations.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/governance/support-and-escalation.md
+++ b/docs-site/src/content/docs/governance/support-and-escalation.md
@@ -1,8 +1,7 @@
 ---
 title: Support and Escalation
 description: Operational support entry points and escalation expectations.
-status: in_review
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/governance/versioning-and-release-policy.md
+++ b/docs-site/src/content/docs/governance/versioning-and-release-policy.md
@@ -1,8 +1,7 @@
 ---
 title: Versioning and Release Policy
 description: Release and documentation versioning policy for OpenQuant.
-status: validated
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/governance/versioning-and-release-policy.md
+++ b/docs-site/src/content/docs/governance/versioning-and-release-policy.md
@@ -2,6 +2,8 @@
 title: Versioning and Release Policy
 description: Release and documentation versioning policy for OpenQuant.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/index.md
+++ b/docs-site/src/content/docs/index.md
@@ -17,8 +17,8 @@ hero:
     - text: Browse Modules
       link: /openquant/modules/
       variant: minimal
-status: validated
-last_validated: '2026-03-02'
+status: reviewed
+last_validated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/index.md
+++ b/docs-site/src/content/docs/index.md
@@ -19,6 +19,8 @@ hero:
       variant: minimal
 status: reviewed
 last_validated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--reviewed">Reviewed</span> A human has read this page end to end. It has not been verified line by line against the code.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/index.md
+++ b/docs-site/src/content/docs/index.md
@@ -3,8 +3,7 @@ title: OpenQuant Documentation
 description: Production-grade documentation for AFML-aligned quantitative research and portfolio engineering with OpenQuant.
 template: splash
 banner:
-  content: |
-    <a href="/openquant/quickstart/">New to OpenQuant? Start with the Quickstart guide →</a>
+  content: '<span class="doc-status doc-status--reviewed">Reviewed</span> <a href="/openquant/quickstart/">New to OpenQuant? Start with the Quickstart guide →</a>'
 hero:
   title: OpenQuant Documentation
   tagline: Institutional-grade quantitative research documentation aligned to AFML chapters and production deployment controls.
@@ -19,8 +18,6 @@ hero:
       variant: minimal
 status: reviewed
 last_validated: '2026-08-30'
-banner:
-  content: '<span class="doc-status doc-status--reviewed">Reviewed</span> A human has read this page end to end. It has not been verified line by line against the code.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/module-reference/api-surfaces.md
+++ b/docs-site/src/content/docs/module-reference/api-surfaces.md
@@ -2,6 +2,8 @@
 title: API Surfaces
 description: High-level Rust and Python API surface map for core workflows.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/module-reference/api-surfaces.md
+++ b/docs-site/src/content/docs/module-reference/api-surfaces.md
@@ -1,8 +1,7 @@
 ---
 title: API Surfaces
 description: High-level Rust and Python API surface map for core workflows.
-status: validated
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/module-reference/by-afml-chapter.md
+++ b/docs-site/src/content/docs/module-reference/by-afml-chapter.md
@@ -1,8 +1,8 @@
 ---
 title: By AFML Chapter
 description: Map AFML concepts to concrete OpenQuant modules and workflows.
-status: validated
-last_validated: '2026-03-02'
+status: reviewed
+last_validated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/module-reference/by-afml-chapter.md
+++ b/docs-site/src/content/docs/module-reference/by-afml-chapter.md
@@ -3,6 +3,8 @@ title: By AFML Chapter
 description: Map AFML concepts to concrete OpenQuant modules and workflows.
 status: reviewed
 last_validated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--reviewed">Reviewed</span> A human has read this page end to end. It has not been verified line by line against the code.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/module-reference/indexing-and-discovery.md
+++ b/docs-site/src/content/docs/module-reference/indexing-and-discovery.md
@@ -1,8 +1,7 @@
 ---
 title: Indexing and Discovery
 description: Navigation model and search strategy for fast access to core OpenQuant capabilities.
-status: validated
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/module-reference/indexing-and-discovery.md
+++ b/docs-site/src/content/docs/module-reference/indexing-and-discovery.md
@@ -2,6 +2,8 @@
 title: Indexing and Discovery
 description: Navigation model and search strategy for fast access to core OpenQuant capabilities.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/adapters.md
+++ b/docs-site/src/content/docs/modules/adapters.md
@@ -4,6 +4,8 @@ description: "Polars DataFrame adapters for signals, events, weights, backtest c
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/adapters.md
+++ b/docs-site/src/content/docs/modules/adapters.md
@@ -1,8 +1,9 @@
 ---
 title: "adapters"
 description: "Polars DataFrame adapters for signals, events, weights, backtest curves, and streaming buffers."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/backtest-statistics.md
+++ b/docs-site/src/content/docs/modules/backtest-statistics.md
@@ -4,6 +4,8 @@ description: "Performance diagnostics for strategy returns and position trajecto
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/backtest-statistics.md
+++ b/docs-site/src/content/docs/modules/backtest-statistics.md
@@ -1,12 +1,14 @@
 ---
 title: "backtest_statistics"
 description: "Performance diagnostics for strategy returns and position trajectories."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "backtest_statistics"
+api_surface: "both"
 risk_notes:
   - "Use annualization constants consistent with your bar frequency."
   - "Deflated Sharpe is useful when strategy mining many variants."
@@ -54,6 +56,19 @@ println!("{sr} {dd:?} {tuw:?}");
 ```
 
 ## API Reference
+
+### Python API
+
+- `backtest_stats.sharpe_ratio`
+- `backtest_stats.information_ratio`
+- `backtest_stats.probabilistic_sharpe_ratio`
+- `backtest_stats.deflated_sharpe_ratio`
+- `backtest_stats.minimum_track_record_length`
+- `backtest_stats.timing_of_flattening_and_flips`
+- `backtest_stats.average_holding_period`
+- `backtest_stats.bets_concentration`
+- `backtest_stats.all_bets_concentration`
+- `backtest_stats.drawdown_and_time_under_water`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/backtesting-engine.md
+++ b/docs-site/src/content/docs/modules/backtesting-engine.md
@@ -4,6 +4,8 @@ description: "Backtesting core with walk-forward, purged CV, and combinatorial p
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/backtesting-engine.md
+++ b/docs-site/src/content/docs/modules/backtesting-engine.md
@@ -1,8 +1,9 @@
 ---
 title: "backtesting_engine"
 description: "Backtesting core with walk-forward, purged CV, and combinatorial purged CV (CPCV) workflows."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/bet-sizing.md
+++ b/docs-site/src/content/docs/modules/bet-sizing.md
@@ -1,12 +1,14 @@
 ---
 title: "bet_sizing"
 description: "Transforms model confidence and constraints into executable position sizes."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "bet_sizing"
+api_surface: "both"
 risk_notes:
   - "Keep sizing logic coupled to latency and fill assumptions; limit price from dynamic sizing is a decision boundary, not a guaranteed fill."
   - "Use reserve sizing when overlapping books or strategy stacking can create hidden gross exposure."
@@ -102,6 +104,37 @@ assert!(!reserve.is_empty());
 ```
 
 ## API Reference
+
+### Python API
+
+- `bet_sizing.get_signal`
+- `bet_sizing.discrete_signal`
+- `bet_sizing.bet_size`
+- `bet_sizing.bet_size_sigmoid`
+- `bet_sizing.bet_size_power`
+- `bet_sizing.inv_price`
+- `bet_sizing.inv_price_sigmoid`
+- `bet_sizing.inv_price_power`
+- `bet_sizing.get_w`
+- `bet_sizing.get_w_sigmoid`
+- `bet_sizing.get_w_power`
+- `bet_sizing.get_target_pos`
+- `bet_sizing.get_target_pos_sigmoid`
+- `bet_sizing.get_target_pos_power`
+- `bet_sizing.limit_price`
+- `bet_sizing.limit_price_sigmoid`
+- `bet_sizing.limit_price_power`
+- `bet_sizing.avg_active_signals`
+- `bet_sizing.bet_size_dynamic`
+- `bet_sizing.cdf_mixture`
+- `bet_sizing.single_bet_size_mixed`
+- `bet_sizing.get_concurrent_sides`
+- `bet_sizing.bet_size_budget`
+- `bet_sizing.bet_size_probability`
+- `bet_sizing.mp_avg_active_signals`
+- `bet_sizing.bet_size_reserve`
+- `bet_sizing.bet_size_reserve_with_fit`
+- `bet_sizing.bet_size_reserve_full`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/bet-sizing.md
+++ b/docs-site/src/content/docs/modules/bet-sizing.md
@@ -4,6 +4,8 @@ description: "Transforms model confidence and constraints into executable positi
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/cla.md
+++ b/docs-site/src/content/docs/modules/cla.md
@@ -4,6 +4,8 @@ description: "Critical Line Algorithm implementation for constrained mean-varian
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/cla.md
+++ b/docs-site/src/content/docs/modules/cla.md
@@ -1,12 +1,14 @@
 ---
 title: "cla"
 description: "Critical Line Algorithm implementation for constrained mean-variance optimization."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "cla"
+api_surface: "both"
 risk_notes:
   - "CLA behavior depends on weight bounds and return estimates."
   - "Use robust covariance estimators when sample size is small."
@@ -51,6 +53,10 @@ let sigma = covariance(&returns);
 ```
 
 ## API Reference
+
+### Python API
+
+- `cla.allocate_cla`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/codependence.md
+++ b/docs-site/src/content/docs/modules/codependence.md
@@ -4,6 +4,8 @@ description: "Dependence metrics beyond linear correlation for feature and asset
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/codependence.md
+++ b/docs-site/src/content/docs/modules/codependence.md
@@ -1,12 +1,14 @@
 ---
 title: "codependence"
 description: "Dependence metrics beyond linear correlation for feature and asset relationships."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "codependence"
+api_surface: "both"
 risk_notes:
   - "Use with clustering and feature pruning workflows."
   - "Bin selection materially impacts MI estimates."
@@ -52,6 +54,16 @@ let dcor = distance_correlation(&x, &y)?;
 ```
 
 ## API Reference
+
+### Python API
+
+- `codependence.angular_distance`
+- `codependence.absolute_angular_distance`
+- `codependence.squared_angular_distance`
+- `codependence.distance_correlation`
+- `codependence.get_optimal_number_of_bins`
+- `codependence.get_mutual_info`
+- `codependence.variation_of_information_score`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/combinatorial-optimization.md
+++ b/docs-site/src/content/docs/modules/combinatorial-optimization.md
@@ -4,6 +4,8 @@ description: "AFML Chapter 21 integer-encoded optimization and trajectory state-
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/combinatorial-optimization.md
+++ b/docs-site/src/content/docs/modules/combinatorial-optimization.md
@@ -1,12 +1,14 @@
 ---
 title: "combinatorial_optimization"
 description: "AFML Chapter 21 integer-encoded optimization and trajectory state-space tooling with exact baselines and solver adapters."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "combinatorial_optimization"
+api_surface: "rust-only"
 risk_notes:
   - "Exact enumeration scales exponentially in decision dimension/horizon; treat it as a correctness baseline and regression oracle."
   - "Use adapter interfaces to compare heuristic/external solvers against exact solutions on small calibration instances before production deployment."

--- a/docs-site/src/content/docs/modules/cross-validation.md
+++ b/docs-site/src/content/docs/modules/cross-validation.md
@@ -4,6 +4,8 @@ description: "Purged cross-validation utilities designed for label overlap and l
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/cross-validation.md
+++ b/docs-site/src/content/docs/modules/cross-validation.md
@@ -1,12 +1,14 @@
 ---
 title: "cross_validation"
 description: "Purged cross-validation utilities designed for label overlap and leakage control."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "cross_validation"
+api_surface: "rust-only"
 risk_notes:
   - "Always align event end-times when purging."
   - "Report variance across folds, not only mean score."

--- a/docs-site/src/content/docs/modules/data-structures.md
+++ b/docs-site/src/content/docs/modules/data-structures.md
@@ -4,6 +4,8 @@ description: "Constructs standard/time/run/imbalance bars from trade streams."
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/data-structures.md
+++ b/docs-site/src/content/docs/modules/data-structures.md
@@ -1,8 +1,9 @@
 ---
 title: "data_structures"
 description: "Constructs standard/time/run/imbalance bars from trade streams."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
@@ -118,10 +119,10 @@ let t_bars = time_bars(&trades, Duration::minutes(5));
 // Dollar bars via standard_bars
 let d_bars = standard_bars(&trades, 50_000.0, StandardBarType::Dollar);
 
-// Run bars
+// Run bars (Rust-only)
 let r_bars = run_bars(&trades, 100);
 
-// Tick imbalance bars
+// Tick imbalance bars (Rust-only)
 let ib = imbalance_bars(&trades, 500.0, ImbalanceBarType::Tick);
 ```
 
@@ -131,7 +132,7 @@ let ib = imbalance_bars(&trades, 500.0, ImbalanceBarType::Tick);
 - Setting the threshold too low, creating extremely noisy high-frequency bars, or too high, losing intraday resolution.
 - Forgetting to assign trade direction (buy/sell sign) before constructing imbalance or run bars — these require signed volume.
 - Mixing bar types across train and inference: if you train on dollar bars, your live pipeline must also use dollar bars with the same threshold.
-- Run bars and imbalance bars are available in Python via `bars.build_run_bars` and `bars.build_imbalance_bars`.
+- Run bars and imbalance bars are available in Python via bars.build_run_bars and bars.build_imbalance_bars.
 
 ## API Reference
 
@@ -143,7 +144,6 @@ let ib = imbalance_bars(&trades, 500.0, ImbalanceBarType::Tick);
 - `bars.build_dollar_bars`
 - `bars.build_run_bars`
 - `bars.build_imbalance_bars`
-- `bars.bar_diagnostics`
 
 ### Rust API
 
@@ -160,7 +160,7 @@ let ib = imbalance_bars(&trades, 500.0, ImbalanceBarType::Tick);
 
 - Threshold selection controls bar frequency and noise level.
 - Keep OHLCV semantics consistent across downstream features.
-- Run bars and imbalance bars are available via `bars.build_run_bars` and `bars.build_imbalance_bars`.
+- Run bars and imbalance bars are available via bars.build_run_bars and bars.build_imbalance_bars.
 - `bar_diagnostics` is Python-only; use it to verify low return autocorrelation after bar construction.
 
 ## Related Modules

--- a/docs-site/src/content/docs/modules/data.md
+++ b/docs-site/src/content/docs/modules/data.md
@@ -4,6 +4,8 @@ description: "OHLCV loading, cleaning, calendar alignment, and data quality repo
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/data.md
+++ b/docs-site/src/content/docs/modules/data.md
@@ -1,13 +1,14 @@
 ---
 title: "data"
 description: "OHLCV loading, cleaning, calendar alignment, and data quality reporting."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "data"
-api_surface: "python-only"
+api_surface: "both"
 risk_notes:
   - "Column aliases are resolved automatically (e.g., 'timestamp' → 'ts', 'ticker' → 'symbol')."
   - "clean_ohlcv deduplicates by (symbol, ts) and sorts chronologically."
@@ -80,8 +81,11 @@ quality = data_quality_report(df)
 - `data.clean_ohlcv`
 - `data.align_calendar`
 - `data.data_quality_report`
+- `data.clean_ohlcv_df`
+- `data.quality_report_df`
+- `data.align_calendar_df`
 
-### Key Functions
+### Rust API
 
 - `load_ohlcv`
 - `clean_ohlcv`

--- a/docs-site/src/content/docs/modules/ef3m.md
+++ b/docs-site/src/content/docs/modules/ef3m.md
@@ -1,12 +1,14 @@
 ---
 title: "ef3m"
 description: "Moment-based mixture fitting utilities for two-normal components."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "ef3m"
+api_surface: "both"
 risk_notes:
   - "Use as initialization for more expensive optimizers."
   - "Sensitive to higher-moment estimation noise."
@@ -51,6 +53,13 @@ let m3 = centered_moment(&moments, 3);
 ```
 
 ## API Reference
+
+### Python API
+
+- `ef3m.centered_moment`
+- `ef3m.raw_moment`
+- `ef3m.most_likely_parameters`
+- `ef3m.fit_m2n`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/ef3m.md
+++ b/docs-site/src/content/docs/modules/ef3m.md
@@ -4,6 +4,8 @@ description: "Moment-based mixture fitting utilities for two-normal components."
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/ensemble-methods.md
+++ b/docs-site/src/content/docs/modules/ensemble-methods.md
@@ -4,6 +4,8 @@ description: "Bias/variance diagnostics and practical bagging-vs-boosting ensemb
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/ensemble-methods.md
+++ b/docs-site/src/content/docs/modules/ensemble-methods.md
@@ -1,12 +1,14 @@
 ---
 title: "ensemble_methods"
 description: "Bias/variance diagnostics and practical bagging-vs-boosting ensemble utilities."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "ensemble_methods"
+api_surface: "both"
 risk_notes:
   - "If base learners are highly correlated, bagging variance reduction is minimal even with many estimators."
   - "Sequential-bootstrap-style sampling is preferable under heavy label overlap and non-IID observations."
@@ -98,6 +100,18 @@ assert_eq!(mean_prob.len(), 3);
 ```
 
 ## API Reference
+
+### Python API
+
+- `ensemble.bias_variance_noise`
+- `ensemble.bootstrap_sample_indices`
+- `ensemble.sequential_bootstrap_sample_indices`
+- `ensemble.aggregate_regression_mean`
+- `ensemble.aggregate_classification_vote`
+- `ensemble.aggregate_classification_probability_mean`
+- `ensemble.average_pairwise_prediction_correlation`
+- `ensemble.bagging_ensemble_variance`
+- `ensemble.recommend_bagging_vs_boosting`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/etf-trick.md
+++ b/docs-site/src/content/docs/modules/etf-trick.md
@@ -1,8 +1,9 @@
 ---
 title: "etf_trick"
 description: "Synthetic ETF and futures roll utilities for realistic PnL path construction."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/etf-trick.md
+++ b/docs-site/src/content/docs/modules/etf-trick.md
@@ -4,6 +4,8 @@ description: "Synthetic ETF and futures roll utilities for realistic PnL path co
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/feature-diagnostics.md
+++ b/docs-site/src/content/docs/modules/feature-diagnostics.md
@@ -1,8 +1,9 @@
 ---
 title: "feature_diagnostics"
 description: "Feature importance diagnostics: MDI, MDA, SFI, PCA orthogonalization, and substitution-effect analysis."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/feature-diagnostics.md
+++ b/docs-site/src/content/docs/modules/feature-diagnostics.md
@@ -4,6 +4,8 @@ description: "Feature importance diagnostics: MDI, MDA, SFI, PCA orthogonalizati
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/feature-importance.md
+++ b/docs-site/src/content/docs/modules/feature-importance.md
@@ -4,6 +4,8 @@ description: "Feature ranking methods: MDI, MDA, and single-feature importance w
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/feature-importance.md
+++ b/docs-site/src/content/docs/modules/feature-importance.md
@@ -1,12 +1,14 @@
 ---
 title: "feature_importance"
 description: "Feature ranking methods: MDI, MDA, and single-feature importance with PCA diagnostics."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "feature_importance"
+api_surface: "rust-only"
 risk_notes:
   - "Cross-validated MDA is preferred when leakage risk is high."
   - "Compare ranking stability across folds/time windows."

--- a/docs-site/src/content/docs/modules/filters.md
+++ b/docs-site/src/content/docs/modules/filters.md
@@ -4,6 +4,8 @@ description: "CUSUM and z-score event filters for event-driven sampling."
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/filters.md
+++ b/docs-site/src/content/docs/modules/filters.md
@@ -1,8 +1,9 @@
 ---
 title: "filters"
 description: "CUSUM and z-score event filters for event-driven sampling."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/fingerprint.md
+++ b/docs-site/src/content/docs/modules/fingerprint.md
@@ -4,6 +4,8 @@ description: "Model fingerprinting for linear, non-linear, and pairwise feature 
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/fingerprint.md
+++ b/docs-site/src/content/docs/modules/fingerprint.md
@@ -1,12 +1,14 @@
 ---
 title: "fingerprint"
 description: "Model fingerprinting for linear, non-linear, and pairwise feature effects."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "fingerprint"
+api_surface: "rust-only"
 risk_notes:
   - "Compare fingerprints across retrains for drift detection."
   - "Use pairwise effects to detect hidden interaction risk."

--- a/docs-site/src/content/docs/modules/fracdiff.md
+++ b/docs-site/src/content/docs/modules/fracdiff.md
@@ -4,6 +4,8 @@ description: "Fractional differentiation to improve stationarity while retaining
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/fracdiff.md
+++ b/docs-site/src/content/docs/modules/fracdiff.md
@@ -1,8 +1,9 @@
 ---
 title: "fracdiff"
 description: "Fractional differentiation to improve stationarity while retaining memory."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
@@ -95,10 +96,10 @@ let out = frac_diff_ffd(&series, 0.4, 1e-4);
 
 ### Python API
 
-- `fracdiff.frac_diff_ffd`
-- `fracdiff.frac_diff`
-- `fracdiff.get_weights_ffd`
 - `fracdiff.get_weights`
+- `fracdiff.get_weights_ffd`
+- `fracdiff.frac_diff`
+- `fracdiff.frac_diff_ffd`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/hcaa.md
+++ b/docs-site/src/content/docs/modules/hcaa.md
@@ -4,6 +4,8 @@ description: "Hierarchical Clustering Asset Allocation variant with cluster-leve
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/hcaa.md
+++ b/docs-site/src/content/docs/modules/hcaa.md
@@ -1,12 +1,14 @@
 ---
 title: "hcaa"
 description: "Hierarchical Clustering Asset Allocation variant with cluster-level constraints."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "hcaa"
+api_surface: "both"
 risk_notes:
   - "Cluster linkage choices influence allocations."
   - "Use with robust codependence distances when possible."
@@ -49,6 +51,10 @@ let w = hcaa.allocate(&prices)?;
 ```
 
 ## API Reference
+
+### Python API
+
+- `hcaa.allocate_hcaa`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/hpc-parallel.md
+++ b/docs-site/src/content/docs/modules/hpc-parallel.md
@@ -4,6 +4,8 @@ description: "AFML Chapter 20 atom/molecule execution utilities with serial/thre
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/hpc-parallel.md
+++ b/docs-site/src/content/docs/modules/hpc-parallel.md
@@ -1,12 +1,14 @@
 ---
 title: "hpc_parallel"
 description: "AFML Chapter 20 atom/molecule execution utilities with serial/threaded modes and partition diagnostics."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "hpc_parallel"
+api_surface: "rust-only"
 risk_notes:
   - "Use `ExecutionMode::Serial` for deterministic debugging with identical callback semantics."
   - "If per-atom cost rises with atom index (e.g., expanding windows), nested partitioning can reduce tail stragglers versus linear chunking."

--- a/docs-site/src/content/docs/modules/hrp.md
+++ b/docs-site/src/content/docs/modules/hrp.md
@@ -1,12 +1,14 @@
 ---
 title: "hrp"
 description: "Hierarchical Risk Parity allocation with recursive bisection."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "hrp"
+api_surface: "both"
 risk_notes:
   - "HRP is often more robust under unstable covariance estimates."
   - "Ensure input asset order tracks produced dendrogram order."
@@ -49,6 +51,10 @@ let weights = hrp.allocate(&prices)?;
 ```
 
 ## API Reference
+
+### Python API
+
+- `hrp.allocate_hrp`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/hrp.md
+++ b/docs-site/src/content/docs/modules/hrp.md
@@ -4,6 +4,8 @@ description: "Hierarchical Risk Parity allocation with recursive bisection."
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/hyperparameter-tuning.md
+++ b/docs-site/src/content/docs/modules/hyperparameter-tuning.md
@@ -4,6 +4,8 @@ description: "Leakage-aware grid/randomized hyper-parameter search with purged C
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/hyperparameter-tuning.md
+++ b/docs-site/src/content/docs/modules/hyperparameter-tuning.md
@@ -1,12 +1,14 @@
 ---
 title: "hyperparameter_tuning"
 description: "Leakage-aware grid/randomized hyper-parameter search with purged CV and weighted scoring."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "hyperparameter_tuning"
+api_surface: "rust-only"
 risk_notes:
   - "Use Accuracy only when each prediction has similar economic value (equal bet sizing)."
   - "Prefer weighted NegLogLoss when probabilities drive position sizing or outcomes have different economic magnitude."

--- a/docs-site/src/content/docs/modules/index.md
+++ b/docs-site/src/content/docs/modules/index.md
@@ -1,8 +1,9 @@
 ---
 title: "Module Reference Index"
 description: "Full OpenQuant module documentation index with AFML-aligned summaries."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/index.md
+++ b/docs-site/src/content/docs/modules/index.md
@@ -4,6 +4,8 @@ description: "Full OpenQuant module documentation index with AFML-aligned summar
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/labeling.md
+++ b/docs-site/src/content/docs/modules/labeling.md
@@ -1,8 +1,9 @@
 ---
 title: "labeling"
 description: "Triple-barrier event labeling and metadata generation."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
@@ -16,8 +17,6 @@ risk_notes:
   - "In meta-labeling, side alignment and timestamp joins are a frequent hidden bug source."
 rust_api:
   - "add_vertical_barrier"
-  - "triple_barrier_events"
-  - "triple_barrier_labels"
   - "get_events"
   - "get_bins"
   - "drop_labels"
@@ -186,10 +185,10 @@ assert!(!meta_bins.is_empty());
 
 ### Python API
 
-- `labeling.add_vertical_barrier`
-- `labeling.triple_barrier_events`
 - `labeling.triple_barrier_labels`
+- `labeling.triple_barrier_events`
 - `labeling.meta_labels`
+- `labeling.add_vertical_barrier`
 - `labeling.get_events`
 - `labeling.get_bins`
 - `labeling.drop_labels`

--- a/docs-site/src/content/docs/modules/labeling.md
+++ b/docs-site/src/content/docs/modules/labeling.md
@@ -4,6 +4,8 @@ description: "Triple-barrier event labeling and metadata generation."
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/microstructural-features.md
+++ b/docs-site/src/content/docs/modules/microstructural-features.md
@@ -1,12 +1,14 @@
 ---
 title: "microstructural_features"
 description: "Price-impact, spread, entropy, and flow toxicity estimators."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "microstructural_features"
+api_surface: "both"
 risk_notes:
   - "Microstructure signals are highly regime-dependent; normalize and standardize within venue/time bucket before cross-asset comparison."
   - "Use shared bar definitions between training and live pipelines, otherwise feature drift is structural."
@@ -101,6 +103,31 @@ assert!(h_plugin.is_finite());
 ```
 
 ## API Reference
+
+### Python API
+
+- `microstructural.get_roll_measure`
+- `microstructural.get_roll_impact`
+- `microstructural.get_corwin_schultz_estimator`
+- `microstructural.get_bekker_parkinson_vol`
+- `microstructural.get_bar_based_kyle_lambda`
+- `microstructural.get_bar_based_amihud_lambda`
+- `microstructural.get_bar_based_hasbrouck_lambda`
+- `microstructural.get_trades_based_kyle_lambda`
+- `microstructural.get_trades_based_amihud_lambda`
+- `microstructural.get_trades_based_hasbrouck_lambda`
+- `microstructural.vwap`
+- `microstructural.get_avg_tick_size`
+- `microstructural.get_vpin`
+- `microstructural.get_bvc_buy_volume`
+- `microstructural.encode_tick_rule_array`
+- `microstructural.quantile_mapping`
+- `microstructural.sigma_mapping`
+- `microstructural.encode_array`
+- `microstructural.get_shannon_entropy`
+- `microstructural.get_lempel_ziv_entropy`
+- `microstructural.get_plug_in_entropy`
+- `microstructural.get_konto_entropy`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/microstructural-features.md
+++ b/docs-site/src/content/docs/modules/microstructural-features.md
@@ -4,6 +4,8 @@ description: "Price-impact, spread, entropy, and flow toxicity estimators."
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/onc.md
+++ b/docs-site/src/content/docs/modules/onc.md
@@ -4,6 +4,8 @@ description: "Optimal Number of Clusters utilities for clustering stability and 
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/onc.md
+++ b/docs-site/src/content/docs/modules/onc.md
@@ -1,12 +1,14 @@
 ---
 title: "onc"
 description: "Optimal Number of Clusters utilities for clustering stability and allocation workflows."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "onc"
+api_surface: "both"
 risk_notes:
   - "Run with repeated seeds/restarts for robust k selection."
   - "Use correlation cleaning before clustering unstable universes."
@@ -50,6 +52,10 @@ println!("{}", out.clusters.len());
 ```
 
 ## API Reference
+
+### Python API
+
+- `onc.get_onc_clusters`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/pipeline.md
+++ b/docs-site/src/content/docs/modules/pipeline.md
@@ -1,13 +1,14 @@
 ---
 title: "pipeline"
 description: "End-to-end AFML research pipeline: events → signals → portfolio → risk → backtest with leakage checks."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "pipeline"
-api_surface: "python-only"
+api_surface: "both"
 risk_notes:
   - "The pipeline enforces input alignment and event ordering as leakage guards."
   - "run_mid_frequency_pipeline_frames adds Polars DataFrames to the raw dict output."
@@ -87,7 +88,7 @@ print(summary)
 - `pipeline.run_mid_frequency_pipeline_frames`
 - `pipeline.summarize_pipeline`
 
-### Key Functions
+### Rust API
 
 - `run_mid_frequency_pipeline`
 - `run_mid_frequency_pipeline_frames`

--- a/docs-site/src/content/docs/modules/pipeline.md
+++ b/docs-site/src/content/docs/modules/pipeline.md
@@ -4,6 +4,8 @@ description: "End-to-end AFML research pipeline: events → signals → portfoli
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/portfolio-optimization.md
+++ b/docs-site/src/content/docs/modules/portfolio-optimization.md
@@ -1,12 +1,14 @@
 ---
 title: "portfolio_optimization"
 description: "Mean-variance and constrained allocation methods with ergonomic APIs."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "portfolio_optimization"
+api_surface: "both"
 risk_notes:
   - "Optimizer output is only as good as mean/covariance assumptions; stress-test inputs and rebalance frequency."
   - "Constraint design (asset caps, sector caps, long/short bounds) is usually more important than small objective tweaks."
@@ -100,6 +102,15 @@ assert!(constrained.weights.iter().all(|w| *w >= -1e-10));
 ```
 
 ## API Reference
+
+### Python API
+
+- `portfolio.allocate_inverse_variance`
+- `portfolio.allocate_min_vol`
+- `portfolio.allocate_max_sharpe`
+- `portfolio.allocate_efficient_risk`
+- `portfolio.allocate_with_solution`
+- `portfolio.allocate_from_inputs`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/portfolio-optimization.md
+++ b/docs-site/src/content/docs/modules/portfolio-optimization.md
@@ -4,6 +4,8 @@ description: "Mean-variance and constrained allocation methods with ergonomic AP
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/research.md
+++ b/docs-site/src/content/docs/modules/research.md
@@ -1,8 +1,9 @@
 ---
 title: "research"
 description: "Synthetic dataset generation and flywheel research iteration with cost modeling and promotion gates."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/research.md
+++ b/docs-site/src/content/docs/modules/research.md
@@ -4,6 +4,8 @@ description: "Synthetic dataset generation and flywheel research iteration with 
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/risk-metrics.md
+++ b/docs-site/src/content/docs/modules/risk-metrics.md
@@ -4,6 +4,8 @@ description: "Portfolio and return-distribution risk measures for downside contr
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/risk-metrics.md
+++ b/docs-site/src/content/docs/modules/risk-metrics.md
@@ -1,12 +1,14 @@
 ---
 title: "risk_metrics"
 description: "Portfolio and return-distribution risk measures for downside control."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "risk_metrics"
+api_surface: "both"
 risk_notes:
   - "Non-parametric estimates need enough tail observations."
   - "Use matrix variants for multi-asset return panels."
@@ -52,6 +54,16 @@ let es95 = RiskMetrics::calculate_expected_shortfall(&r, 0.05)?;
 ```
 
 ## API Reference
+
+### Python API
+
+- `risk.calculate_value_at_risk`
+- `risk.calculate_expected_shortfall`
+- `risk.calculate_conditional_drawdown_risk`
+- `risk.calculate_variance`
+- `risk.calculate_value_at_risk_from_matrix`
+- `risk.calculate_expected_shortfall_from_matrix`
+- `risk.calculate_conditional_drawdown_risk_from_matrix`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/sample-weights.md
+++ b/docs-site/src/content/docs/modules/sample-weights.md
@@ -4,6 +4,8 @@ description: "Sample weighting utilities for overlapping event structure."
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/sample-weights.md
+++ b/docs-site/src/content/docs/modules/sample-weights.md
@@ -1,8 +1,9 @@
 ---
 title: "sample_weights"
 description: "Sample weighting utilities for overlapping event structure."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/sampling.md
+++ b/docs-site/src/content/docs/modules/sampling.md
@@ -1,8 +1,9 @@
 ---
 title: "sampling"
 description: "Indicator matrix and sequential bootstrap tooling."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
@@ -15,11 +16,8 @@ risk_notes:
   - "Use average uniqueness as a diagnostics KPI."
 rust_api:
   - "get_ind_matrix"
-  - "get_ind_mat_average_uniqueness"
-  - "get_ind_mat_label_uniqueness"
-  - "bootstrap_loop_run"
   - "seq_bootstrap"
-  - "get_av_uniqueness_from_triple_barrier"
+  - "get_ind_mat_average_uniqueness"
   - "num_concurrent_events"
 sidebar:
   badge: Module
@@ -110,21 +108,18 @@ let idx = seq_bootstrap(&ind, Some(3), None);
 ### Python API
 
 - `sampling.get_ind_matrix`
+- `sampling.seq_bootstrap`
 - `sampling.get_ind_mat_average_uniqueness`
 - `sampling.get_ind_mat_label_uniqueness`
 - `sampling.bootstrap_loop_run`
-- `sampling.seq_bootstrap`
 - `sampling.get_av_uniqueness_from_triple_barrier`
 - `sampling.num_concurrent_events`
 
 ### Rust API
 
 - `get_ind_matrix`
-- `get_ind_mat_average_uniqueness`
-- `get_ind_mat_label_uniqueness`
-- `bootstrap_loop_run`
 - `seq_bootstrap`
-- `get_av_uniqueness_from_triple_barrier`
+- `get_ind_mat_average_uniqueness`
 - `num_concurrent_events`
 
 ## Implementation Notes

--- a/docs-site/src/content/docs/modules/sampling.md
+++ b/docs-site/src/content/docs/modules/sampling.md
@@ -4,6 +4,8 @@ description: "Indicator matrix and sequential bootstrap tooling."
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/sb-bagging.md
+++ b/docs-site/src/content/docs/modules/sb-bagging.md
@@ -4,6 +4,8 @@ description: "Sequentially bootstrapped bagging classifiers/regressors."
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/sb-bagging.md
+++ b/docs-site/src/content/docs/modules/sb-bagging.md
@@ -1,12 +1,14 @@
 ---
 title: "sb_bagging"
 description: "Sequentially bootstrapped bagging classifiers/regressors."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "sb_bagging"
+api_surface: "both"
 risk_notes:
   - "Sequential bootstrap improves diversity under event overlap."
   - "Tune max_samples/max_features with out-of-sample monitoring."
@@ -50,6 +52,11 @@ let bag = SequentiallyBootstrappedBaggingClassifier::new(100);
 ```
 
 ## API Reference
+
+### Python API
+
+- `sb_bagging.fit_predict_sb_classifier`
+- `sb_bagging.fit_predict_sb_regressor`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/strategy-risk.md
+++ b/docs-site/src/content/docs/modules/strategy-risk.md
@@ -4,6 +4,8 @@ description: "AFML Chapter 15 strategy-viability diagnostics based on precision,
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/strategy-risk.md
+++ b/docs-site/src/content/docs/modules/strategy-risk.md
@@ -1,12 +1,14 @@
 ---
 title: "strategy_risk"
 description: "AFML Chapter 15 strategy-viability diagnostics based on precision, payout asymmetry, and bet frequency."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "strategy_risk"
+api_surface: "both"
 risk_notes:
   - "Inputs under manager control ({pi_minus, pi_plus, n}) should be analyzed separately from uncertain market precision p."
   - "Use this module for strategy-level viability and probability-of-failure diagnostics; use `risk_metrics` for portfolio-tail and drawdown risk."
@@ -73,6 +75,16 @@ println!("failure (KDE): {:.2}%", 100.0 * report.kde_failure_probability);
 ```
 
 ## API Reference
+
+### Python API
+
+- `strategy_risk.sharpe_symmetric`
+- `strategy_risk.implied_precision_symmetric`
+- `strategy_risk.implied_frequency_symmetric`
+- `strategy_risk.sharpe_asymmetric`
+- `strategy_risk.implied_precision_asymmetric`
+- `strategy_risk.implied_frequency_asymmetric`
+- `strategy_risk.estimate_strategy_failure_probability`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/streaming-hpc.md
+++ b/docs-site/src/content/docs/modules/streaming-hpc.md
@@ -1,12 +1,14 @@
 ---
 title: "streaming_hpc"
 description: "AFML Chapter 22 streaming analytics utilities for low-latency early-warning metrics with bounded-memory incremental state."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "streaming_hpc"
+api_surface: "both"
 risk_notes:
   - "Chapter 22 stresses turnaround-time over pure throughput: bounded rolling windows avoid unbounded latency/memory growth."
   - "For low-latency alerts, keep stream partitioning stable and calibrate `mp_batches` against scheduling overhead and cache locality."
@@ -92,6 +94,11 @@ println!("streams={} molecules={} events/s={:.0}",
 ```
 
 ## API Reference
+
+### Python API
+
+- `streaming_hpc.run_streaming_pipeline`
+- `streaming_hpc.generate_synthetic_flash_crash_stream`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/streaming-hpc.md
+++ b/docs-site/src/content/docs/modules/streaming-hpc.md
@@ -4,6 +4,8 @@ description: "AFML Chapter 22 streaming analytics utilities for low-latency earl
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/structural-breaks.md
+++ b/docs-site/src/content/docs/modules/structural-breaks.md
@@ -1,12 +1,14 @@
 ---
 title: "structural_breaks"
 description: "Regime change and bubble diagnostics (Chow, CUSUM variants, SADF)."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "structural_breaks"
+api_surface: "both"
 risk_notes:
   - "SADF can be computationally expensive on long windows."
   - "Use dedicated slow/nightly test paths for heavy scenarios."
@@ -51,6 +53,12 @@ let sadf = get_sadf(&y, 3, SadfLags::Fixed(1))?;
 ```
 
 ## API Reference
+
+### Python API
+
+- `structural_breaks.get_chow_type_stat`
+- `structural_breaks.get_chu_stinchcombe_white_statistics`
+- `structural_breaks.get_sadf`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/structural-breaks.md
+++ b/docs-site/src/content/docs/modules/structural-breaks.md
@@ -4,6 +4,8 @@ description: "Regime change and bubble diagnostics (Chow, CUSUM variants, SADF).
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/synthetic-backtesting.md
+++ b/docs-site/src/content/docs/modules/synthetic-backtesting.md
@@ -1,12 +1,14 @@
 ---
 title: "synthetic_backtesting"
 description: "Synthetic-data OTR backtesting with O-U calibration, PT/SL mesh search, and stability diagnostics."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "synthetic_backtesting"
+api_surface: "both"
 risk_notes:
   - "Near-random-walk estimates (|phi| close to 1) often produce flat Sharpe heatmaps where any selected rule is unstable out-of-sample."
   - "Calibrating to process parameters and evaluating many synthetic paths reduces single-path lucky-fit risk compared to brute-force historical optimization."
@@ -73,6 +75,15 @@ if out.diagnostics.no_stable_optimum {
 ```
 
 ## API Reference
+
+### Python API
+
+- `synthetic_bt.calibrate_ou_params`
+- `synthetic_bt.generate_ou_paths`
+- `synthetic_bt.evaluate_rule_on_paths`
+- `synthetic_bt.detect_no_stable_optimum`
+- `synthetic_bt.run_synthetic_otr_workflow`
+- `synthetic_bt.search_optimal_trading_rule`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/synthetic-backtesting.md
+++ b/docs-site/src/content/docs/modules/synthetic-backtesting.md
@@ -4,6 +4,8 @@ description: "Synthetic-data OTR backtesting with O-U calibration, PT/SL mesh se
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/util-fast-ewma.md
+++ b/docs-site/src/content/docs/modules/util-fast-ewma.md
@@ -1,12 +1,14 @@
 ---
 title: "util::fast_ewma"
 description: "Fast EWMA primitive shared across feature and volatility routines."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "util::fast_ewma"
+api_surface: "both"
 risk_notes:
   - "Window length controls responsiveness vs smoothness."
   - "Prefer this helper over ad-hoc loops for consistency."
@@ -48,6 +50,10 @@ let y = ewma(&x, 3);
 ```
 
 ## API Reference
+
+### Python API
+
+- `fast_ewma.ewma`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/util-fast-ewma.md
+++ b/docs-site/src/content/docs/modules/util-fast-ewma.md
@@ -4,6 +4,8 @@ description: "Fast EWMA primitive shared across feature and volatility routines.
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/util-volatility.md
+++ b/docs-site/src/content/docs/modules/util-volatility.md
@@ -4,6 +4,8 @@ description: "Volatility estimators used across labeling and risk workflows."
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/util-volatility.md
+++ b/docs-site/src/content/docs/modules/util-volatility.md
@@ -1,12 +1,14 @@
 ---
 title: "util::volatility"
 description: "Volatility estimators used across labeling and risk workflows."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering
 module: "util::volatility"
+api_surface: "both"
 risk_notes:
   - "Choose estimator based on available fields and microstructure noise."
   - "Daily-vol lookback should be matched to event horizon."
@@ -51,6 +53,13 @@ let pv = get_parksinson_vol(&high, &low, 20);
 ```
 
 ## API Reference
+
+### Python API
+
+- `volatility.get_daily_vol`
+- `volatility.get_parksinson_vol`
+- `volatility.get_garman_class_vol`
+- `volatility.get_yang_zhang_vol`
 
 ### Rust API
 

--- a/docs-site/src/content/docs/modules/viz.md
+++ b/docs-site/src/content/docs/modules/viz.md
@@ -1,8 +1,9 @@
 ---
 title: "viz"
 description: "Visualization payload builders for feature importance, drawdown, regime, frontier, and cluster charts."
-status: validated
-last_validated: '2026-03-02'
+status: generated
+generated_from: src/data/moduleDocs.ts
+last_generated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/modules/viz.md
+++ b/docs-site/src/content/docs/modules/viz.md
@@ -4,6 +4,8 @@ description: "Visualization payload builders for feature importance, drawdown, r
 status: generated
 generated_from: src/data/moduleDocs.ts
 last_generated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--generated">Generated</span> Assembled automatically from <code>moduleDocs.ts</code>. No human has reviewed this page.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/quickstart.md
+++ b/docs-site/src/content/docs/quickstart.md
@@ -1,8 +1,8 @@
 ---
 title: Quickstart
 description: Execute the first-run OpenQuant validation path in under 30 minutes.
-status: validated
-last_validated: '2026-03-02'
+status: reviewed
+last_validated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/quickstart.md
+++ b/docs-site/src/content/docs/quickstart.md
@@ -3,6 +3,8 @@ title: Quickstart
 description: Execute the first-run OpenQuant validation path in under 30 minutes.
 status: reviewed
 last_validated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--reviewed">Reviewed</span> A human has read this page end to end. It has not been verified line by line against the code.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/quickstart.md
+++ b/docs-site/src/content/docs/quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Quickstart
-description: Execute the first-run OpenQuant validation path in under 30 minutes.
+description: Install OpenQuant and get one real result out of it.
 status: reviewed
 last_validated: '2026-08-30'
 banner:
@@ -12,67 +12,163 @@ sidebar:
   order: 1
 ---
 
-## Goal
+Three steps, ending in a number OpenQuant computed for you. Budget
+**20–30 minutes**, nearly all of it the Rust compile in step 2.
 
-Confirm that your local environment can run OpenQuant's core tests and documentation quality gates.
+You need a Rust toolchain, a linker, and `uv`. If you do not have them,
+start at [Prerequisites](/setup/prerequisites/) and come back — it is
+four commands.
 
-## Step 1: Clone and enter repository
+## Step 1 — Clone
 
 ```bash
 git clone https://github.com/Open-Quant/openquant.git
 cd openquant
 ```
 
-## Step 2: Run fast library validation
+## Step 2 — Install
+
+`openquant` is not on PyPI: the Python package sits on a compiled PyO3
+extension, so installing it means building it.
 
 ```bash
-cargo test --workspace --lib --tests --all-features -- --skip test_sadf_test
+uv venv --python 3.11 .venv
+
+uv run --python .venv/bin/python --with maturin \
+  maturin develop --manifest-path crates/pyopenquant/Cargo.toml
+
+uv run --python .venv/bin/python python -c "import openquant; print('openquant bindings import ok')"
 ```
 
-Expected result:
-- non-slow test suite passes.
+This compiles the whole Rust workspace — `polars`, `nalgebra` and their
+dependency trees — so **expect 10–20 minutes on a cold cache**. Later
+builds are incremental and take seconds.
 
-## Step 3: Run slow structural-break hotspot
+The third command should print:
 
-```bash
-cargo test -p openquant --test structural_breaks test_sadf_test -- --ignored
+```
+openquant bindings import ok
 ```
 
-Expected result:
-- explicit slow-path test passes.
+If it does not, [Troubleshooting](/setup/troubleshooting/) has the
+failures worth knowing about, and the architecture mismatch one is the
+most common on macOS.
 
-## Step 4: Validate docs build and quality gates
+## Step 3 — Get a result
 
-```bash
-cd docs-site
-bun run check:docs
-```
-
-Expected result:
-- `build`, `check:links`, `check:api-drift`, and `check:content-schema` all pass.
-
-## Step 5: Run your first research workflow
+Save this as `first_run.py` in the repository root:
 
 ```python
 from openquant.research import make_synthetic_futures_dataset, run_flywheel_iteration
 
-# Generate deterministic synthetic multi-asset futures data
+# Deterministic synthetic multi-asset futures data: 192 one-minute bars,
+# four instruments. No market data feed required.
 dataset = make_synthetic_futures_dataset(n_bars=192, seed=7)
 
-# Run a complete AFML pipeline: events → labels → sizing → portfolio → risk
+# One full AFML iteration: events -> labels -> sizing -> backtest ->
+# portfolio -> risk, then trading costs and promotion gates.
 result = run_flywheel_iteration(dataset)
 
-# Inspect key metrics
-print(result["summary"])
-# portfolio_sharpe | realized_sharpe | value_at_risk | net_sharpe | turnover
+print("leakage checks:")
+for k, v in result["leakage_checks"].items():
+    print(f"  {k:<24} {v}")
 
-# Check promotion gates (is this strategy viable?)
-print(result["promotion"])
-# {'passed_net_sharpe': True, 'promote_candidate': True, ...}
+print("\nsummary:")
+summary = result["summary"].transpose(include_header=True, header_name="metric", column_names=["value"])
+for metric, value in summary.iter_rows():
+    print(f"  {metric:<26} {value:>12.6f}")
+
+print("\npromotion gates:")
+for k, v in result["promotion"].items():
+    print(f"  {k:<26} {v}")
 ```
 
-## Step 6: Continue to workflow docs
+Run it:
 
-- [Rust Core Workflow](/workflows/rust-core-workflow/)
-- [Python Core Workflow](/workflows/python-core-workflow/)
-- [Module Reference Index](/modules/)
+```bash
+uv run --python .venv/bin/python python first_run.py
+```
+
+Here is what it printed on the machine this page was written on. The
+dataset is seeded, so you should see the same numbers:
+
+```text
+leakage checks:
+  inputs_aligned           True
+  event_indices_sorted     True
+  has_forward_look_bias    False
+
+summary:
+  portfolio_sharpe               8.319781
+  portfolio_return               0.020480
+  portfolio_risk                 0.002462
+  realized_sharpe               -0.136778
+  value_at_risk                 -0.000209
+  expected_shortfall            -0.000312
+  conditional_drawdown_risk      0.000768
+  inputs_aligned                 1.000000
+  event_indices_sorted           1.000000
+  has_forward_look_bias          0.000000
+  turnover                       3.600000
+  realized_vol                   0.001884
+  estimated_cost                 0.001314
+  gross_total_return            -0.000197
+  net_total_return              -0.001511
+  net_sharpe                    -0.194432
+
+promotion gates:
+  passed_realized_sharpe     False
+  passed_net_sharpe          False
+  passed_alignment_guard     True
+  passed_event_order_guard   True
+  promote_candidate          False
+```
+
+**The candidate was rejected, and that is the correct result.** The
+synthetic dataset's "model probabilities" are a sine wave, not a model.
+A quickstart that printed a promoted strategy would be teaching you to
+trust the wrong thing.
+
+## What you just ran
+
+`run_flywheel_iteration` executed the full AFML loop: CUSUM event
+sampling, triple-barrier labeling, probability-to-position sizing, a
+backtest, portfolio allocation and risk metrics — then charged the result
+for commission, spread and slippage, and applied promotion gates.
+
+Three things in that output are worth understanding now, because they are
+the habits the rest of the library is built around.
+
+**The leakage checks come first.** `inputs_aligned` and
+`event_indices_sorted` are the pipeline asserting it was handed coherent
+inputs. Two of the four `promotion` gates are these checks, not
+performance thresholds. A candidate cannot be promoted on returns alone.
+
+**Gross and net are different numbers.** `gross_total_return` is
+-0.000197; `net_total_return` is -0.001511. The gap is `estimated_cost`,
+which is `turnover` (3.6) times a per-turn charge built from commission,
+spread and a volatility-scaled slippage term. `net_sharpe` is recomputed
+after that charge. For a mid-frequency strategy this gap is usually the
+whole story.
+
+**`portfolio_sharpe` is not your strategy's Sharpe.** It reads 8.32 above
+while `realized_sharpe` is -0.14. They answer different questions:
+`portfolio_sharpe` is the in-sample optimum of the allocator across the
+four synthetic assets, and `realized_sharpe` is what the traded strategy
+actually returned. Reading the first as the second is the single easiest
+way to convince yourself you have found something.
+
+## Next
+
+| If you want to… | Go here |
+|---|---|
+| Understand each stage of that loop | [Python Core Workflow](/workflows/python-core-workflow/) |
+| Do the same thing in Rust | [Rust Core Workflow](/workflows/rust-core-workflow/) |
+| Run it on your own CSV | [Examples Catalog](/examples/catalog/) |
+| Build and test the repo itself | [Local Build Setup](/setup/local-build/) |
+
+The repo's own test suite and documentation gates are *maintainer*
+commands, not first-run commands. They live on [Local Build
+Setup](/setup/local-build/); running them proves the repository is
+healthy, which is a different question from whether OpenQuant is useful
+to you.

--- a/docs-site/src/content/docs/setup/local-build.md
+++ b/docs-site/src/content/docs/setup/local-build.md
@@ -3,6 +3,8 @@ title: Local Build Setup
 description: Deterministic local build and validation sequence.
 status: reviewed
 last_validated: '2026-08-30'
+banner:
+  content: '<span class="doc-status doc-status--reviewed">Reviewed</span> A human has read this page end to end. It has not been verified line by line against the code.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/setup/local-build.md
+++ b/docs-site/src/content/docs/setup/local-build.md
@@ -1,8 +1,8 @@
 ---
 title: Local Build Setup
 description: Deterministic local build and validation sequence.
-status: validated
-last_validated: '2026-03-02'
+status: reviewed
+last_validated: '2026-08-30'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/setup/local-build.md
+++ b/docs-site/src/content/docs/setup/local-build.md
@@ -1,6 +1,6 @@
 ---
 title: Local Build Setup
-description: Deterministic local build and validation sequence.
+description: Build the Rust core, run its tests, and run the documentation quality gates.
 status: reviewed
 last_validated: '2026-08-30'
 banner:
@@ -12,25 +12,92 @@ sidebar:
   order: 2
 ---
 
-## Build and test sequence
+This is the maintainer path: compile the Rust core and run the gates CI
+runs. If you are here to *use* OpenQuant rather than to change it, the
+[Quickstart](/quickstart/) is shorter and ends with a result.
+
+## Build and test the Rust core
 
 ```bash
+cargo build --all-features
 cargo test --workspace --lib --tests --all-features -- --skip test_sadf_test
+```
+
+The `--skip` is deliberate. `test_sadf_test` is annotated `#[ignore]` in
+`crates/openquant/tests/structural_breaks.rs` as a "long-running
+hotspot", so it does not run by default; the explicit skip keeps the
+command honest if the annotation is ever removed. Run it on its own when
+you have touched `structural_breaks`:
+
+```bash
 cargo test -p openquant --test structural_breaks test_sadf_test -- --ignored
 ```
 
-## Docs quality gates
+Lint and format, mirroring the `lint` recipe in the `justfile`:
+
+```bash
+cargo fmt -- --check
+cargo clippy --all-targets --all-features -- -D clippy::correctness -D clippy::suspicious
+```
+
+## Documentation quality gates
 
 ```bash
 cd docs-site
-bun run build
-bun run check:links
-bun run check:api-drift
-bun run check:content-schema
+npm install
+npx astro build
+node scripts/check-links.mjs
+python3 ../scripts/generate_api_inventory.py --check
+node scripts/check-content-schema.mjs
 ```
 
+`package.json` wraps these as `bun run check:docs`, and the deploy
+workflow uses Bun — but nothing here needs Bun as a runtime, and the npm
+form above is what these commands were last verified with. If you have
+Bun, `bun run check:docs` runs all four in order.
+
 Expected checkpoints:
-- Build succeeds.
-- Link checks return zero broken internal links.
-- API drift check is clean.
-- Content schema check passes.
+
+- `astro build` completes and reports the page count.
+- `check:links` returns zero broken internal links.
+- `check:api-drift` is clean.
+- `check:content-schema` prints a per-status tally of all docs files.
+
+## When a gate fails
+
+**`check:links` reports broken links.** Run `astro build` first. The link
+checker reads the built output in `dist/`, not the Markdown sources, so a
+stale or absent `dist/` produces phantom failures. Internal links must
+resolve under the `/openquant` base path once built — a link that works
+in `astro dev` can still 404 in production if it omits the base.
+
+**`check:api-drift` fails.** The inventory under `scripts/` no longer
+matches the code. If you changed a public API on purpose, regenerate the
+inventory from the repository root and commit the result; if you did not,
+you have changed a public API by accident and the gate is doing its job.
+
+**`check:content-schema` fails.** The message names the file and the rule.
+The taxonomy is defined at the top of
+`docs-site/scripts/check-content-schema.mjs`:
+
+| `status` | Means | Date field it must carry |
+|---|---|---|
+| `generated` | emitted from `src/data/moduleDocs.ts`; nobody has read it | `last_generated` |
+| `draft` | hand-written, known incomplete; claims nothing | **none** |
+| `reviewed` | a human read the page end to end | `last_validated` |
+| `validated` | reviewed *and* checked against the code it describes | `last_validated` |
+
+Two rules catch most failures. A `draft` may not carry `last_validated` —
+drop the field or raise the status. And a stamp may not predate the
+page's last content change: if you edited a page, either re-read it and
+bump the date, or lower the status to `draft`. The gate reads the change
+date from `git log` plus the working-tree mtime, so an uncommitted edit
+counts.
+
+The reader-facing badge in each page's `banner.content` must also match
+`status`. Change one, change the other.
+
+## Next
+
+- [Python Bindings Setup](/setup/python-bindings/) — the PyO3 extension
+- [Troubleshooting](/setup/troubleshooting/) — compile and link failures

--- a/docs-site/src/content/docs/setup/prerequisites.md
+++ b/docs-site/src/content/docs/setup/prerequisites.md
@@ -1,9 +1,10 @@
 ---
 title: Prerequisites
-description: Required toolchain and environment assumptions for OpenQuant docs and development.
-status: draft
+description: Toolchain OpenQuant requires, how to install it on each platform, and why each version floor exists.
+status: reviewed
+last_validated: '2026-08-30'
 banner:
-  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
+  content: '<span class="doc-status doc-status--reviewed">Reviewed</span> A human has read this page end to end. It has not been verified line by line against the code.'
 audience:
   - quant-dev
   - platform-engineering
@@ -11,10 +12,109 @@ sidebar:
   order: 1
 ---
 
-- Rust stable toolchain (`rustup default stable`)
-- Python 3.10+
-- Bun 1.3+ (docs-site package manager)
-- Git
+You need four things: a Rust toolchain, a C linker, `uv`, and Git. Node is
+needed only if you are working on the documentation site.
 
-Optional:
-- GitHub Actions access for release/documentation automation validation.
+## Install
+
+### macOS
+
+```bash
+xcode-select --install                                     # clang + linker
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+Git ships with the Command Line Tools installed by the first command.
+
+:::caution[Apple Silicon: match the architectures]
+`rustup` will happily install an `x86_64-apple-darwin` toolchain on an
+arm64 Mac (this happens if you ever ran it under Rosetta). The Python
+bindings will then fail to build, because `maturin` asks `cargo` for the
+architecture of *your Python interpreter*, not of your Rust toolchain.
+Check with:
+
+```bash
+rustup show | head -3
+python3 -c "import platform; print(platform.machine())"
+```
+
+If the first says `x86_64` and the second says `arm64`, see
+[Troubleshooting → Rust toolchain and Python interpreter disagree on
+architecture](/setup/troubleshooting/#rust-toolchain-and-python-interpreter-disagree-on-architecture).
+:::
+
+### Debian / Ubuntu
+
+```bash
+sudo apt-get update && sudo apt-get install -y build-essential git curl
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+`build-essential` is not optional: it supplies `cc`, which `rustc` invokes
+as its linker. Without it every Rust build fails at the link step with
+`linker 'cc' not found`.
+
+### Windows
+
+Use WSL2 and follow the Debian/Ubuntu instructions. The CI matrix
+(`.github/workflows/`) runs `ubuntu-latest` only, so a native Windows
+build is unverified by this project.
+
+### Verify
+
+```bash
+rustc --version && cargo --version && uv --version && git --version
+```
+
+## Version floors, and why
+
+| Tool | Floor | Where it is declared | Why |
+|---|---|---|---|
+| Rust | stable | `dtolnay/rust-toolchain@stable` in every CI workflow | **No MSRV is declared anywhere in this repo** — there is no `rust-version` key in any `Cargo.toml` and no `rust-toolchain.toml`. Both crates are `edition = "2021"`, and `pyo3 0.23` / `polars 0.46` pull the real floor well above edition 2021's own 1.56. Treat "current stable" as the only supported answer, because that is the only one CI proves. |
+| Python | 3.9 minimum, **3.11 recommended** | `requires-python = ">=3.9"` in `pyproject.toml` | 3.9 is the floor the package metadata will enforce at install time. 3.11 is what `.github/workflows/python-bindings.yml` actually builds and tests against, so it is the version with evidence behind it. See the caveat below. |
+| `uv` | any recent release | not pinned | Every `just py-*` recipe shells out to `uv`, and CI installs it via `astral-sh/setup-uv@v5`. It is the project's only supported way to create the Python environment. |
+| Node | 20 | `node-version: 20` in `.github/workflows/docs-pages.yml` | Docs site only. Astro 5 requires Node 18.17+; CI uses 20. |
+| Bun | latest | `oven-sh/setup-bun@v2` in `docs-pages.yml` | Docs site only, and **optional** — see below. |
+
+:::note[The repo disagrees with itself about the Python version]
+Three different Python versions are declared in-tree:
+
+- `pyproject.toml` — `requires-python = ">=3.9"`
+- `.github/workflows/python-bindings.yml` — `python-version: "3.11"`
+- `justfile`, recipe `py-setup` — `uv venv --python 3.13 .venv`
+
+Only 3.11 is exercised by CI. This page recommends 3.11 for that reason.
+3.13 was built successfully while writing this page, but 3.9 and 3.10 have
+not been tested by anyone here and the `>=3.9` claim should be treated as
+aspirational rather than verified.
+:::
+
+:::note[Bun is not required]
+`docs-site/package.json` defines `check:docs` as a chain of `bun run`
+commands, and the docs deploy workflow uses Bun. Nothing in the docs site
+depends on Bun as a *runtime*, though — it is used purely as a package
+manager and script runner. npm works:
+
+```bash
+cd docs-site
+npm install
+npx astro build
+```
+
+That is the path used to verify every docs command on this site. If you do
+want Bun, install it with `curl -fsSL https://bun.sh/install | bash`.
+:::
+
+## Rust dependencies that need no action
+
+The workspace vendors a patched `pyo3-polars` (`vendor/pyo3-polars`, wired
+up by a `[patch.crates-io]` entry in the root `Cargo.toml`). It is checked
+in, so `cargo build` resolves it with no extra setup — but it does mean
+`Cargo.lock` is authoritative and you should not delete it.
+
+## Next
+
+- [Local Build Setup](/setup/local-build/) — build and test the Rust core
+- [Python Bindings Setup](/setup/python-bindings/) — build and import the Python package

--- a/docs-site/src/content/docs/setup/prerequisites.md
+++ b/docs-site/src/content/docs/setup/prerequisites.md
@@ -2,6 +2,8 @@
 title: Prerequisites
 description: Required toolchain and environment assumptions for OpenQuant docs and development.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/setup/prerequisites.md
+++ b/docs-site/src/content/docs/setup/prerequisites.md
@@ -1,8 +1,7 @@
 ---
 title: Prerequisites
 description: Required toolchain and environment assumptions for OpenQuant docs and development.
-status: validated
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/setup/python-bindings.md
+++ b/docs-site/src/content/docs/setup/python-bindings.md
@@ -1,9 +1,10 @@
 ---
 title: Python Bindings Setup
-description: Baseline guidance for Python package workflow integration.
-status: draft
+description: Build the PyO3 extension, install it into a virtual environment, and prove it imports.
+status: reviewed
+last_validated: '2026-08-30'
 banner:
-  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
+  content: '<span class="doc-status doc-status--reviewed">Reviewed</span> A human has read this page end to end. It has not been verified line by line against the code.'
 audience:
   - quant-dev
   - platform-engineering
@@ -11,19 +12,123 @@ sidebar:
   order: 3
 ---
 
-OpenQuant currently exposes Python workflow APIs used in data, bars, diagnostics, and pipeline tracks.
+`openquant` is not on PyPI. The Python package is a thin pure-Python layer
+(`python/openquant/`) over a compiled PyO3 extension
+(`crates/pyopenquant/`, built as `openquant._core`), so getting it means
+building it. There is no `pip install openquant` that will work.
 
-## Validation command
+Before you start: [Prerequisites](/setup/prerequisites/). You need a Rust
+toolchain, a linker, and `uv`.
+
+## Setup
+
+Four commands, from the repository root. This is the sequence
+`.github/workflows/python-bindings.yml` runs on every PR that touches the
+bindings, so it is the one with continuous evidence behind it.
 
 ```bash
-cargo test --workspace --lib --tests --all-features -- --skip test_sadf_test
+# 1. Create an isolated interpreter. 3.11 is what CI builds against.
+uv venv --python 3.11 .venv
+
+# 2. Compile the extension and install it into that environment.
+uv run --python .venv/bin/python --with maturin \
+  maturin develop --manifest-path crates/pyopenquant/Cargo.toml
+
+# 3. Prove it imports.
+uv run --python .venv/bin/python python -c "import openquant; print('openquant bindings import ok')"
+
+# 4. Prove it works.
+uv run --python .venv/bin/python --with pytest pytest python/tests -q
 ```
 
-## Core Python surfaces to review
+Step 2 compiles the whole Rust workspace — `polars`, `nalgebra` and their
+dependency trees. Budget **10–20 minutes on a cold cache**; subsequent
+runs are incremental and take seconds.
 
-- `openquant.data`
-- `openquant.bars`
-- `openquant.feature_diagnostics`
-- `openquant.pipeline`
+Expected output from steps 3 and 4:
 
-Reference: [API Surfaces](/module-reference/api-surfaces/)
+```
+openquant bindings import ok
+```
+
+```
+................................                                         [100%]
+32 passed in 2.52s
+```
+
+### The `just` equivalents
+
+The same flow is wrapped in the `justfile`, if you have
+[`just`](https://github.com/casey/just):
+
+```bash
+just py-setup          # uv venv --python 3.13 .venv && uv sync --group dev
+just py-develop        # maturin develop
+just py-import-smoke   # import openquant; print('openquant bindings OK')
+just py-test           # pytest python/tests -q
+```
+
+:::caution[`just py-setup` is not the same as the CI path]
+`py-setup` pins Python **3.13** where CI uses **3.11**, and it uses
+`uv sync` rather than `--with maturin`. `uv sync` builds the project
+through maturin's PEP 517 hook, which swallows the compiler's error
+output and reports only `returned non-zero exit status 1` — see
+[Troubleshooting](/setup/troubleshooting/#uv-sync-fails-with-an-opaque-pep517-build-wheel-error).
+Prefer the four explicit commands above when something is going wrong.
+:::
+
+## Building a wheel
+
+`maturin develop` installs in place, which is what you want for
+development. To produce a distributable wheel:
+
+```bash
+uv run --python .venv/bin/python --with maturin \
+  maturin build --manifest-path crates/pyopenquant/Cargo.toml --out dist
+```
+
+The wheel lands in `dist/` and is installable into any interpreter of the
+**same** Python minor version and platform it was built for — the
+extension is ABI-specific. There is no `abi3` configuration in
+`crates/pyopenquant/Cargo.toml`, so a 3.11 wheel will not load on 3.12.
+
+## Smoke test the real surface
+
+Once step 3 passes, this exercises the layer you actually came for. It
+runs entirely on generated data, so it needs no market data feed:
+
+```python
+from openquant.research import make_synthetic_futures_dataset, run_flywheel_iteration
+
+dataset = make_synthetic_futures_dataset(n_bars=192, seed=7)
+result = run_flywheel_iteration(dataset)
+
+print(result["summary"])
+print(result["promotion"])
+```
+
+`result["summary"]` is a `polars.DataFrame`, `result["promotion"]` a
+`dict` of boolean gates. For what the numbers mean, see
+[Python Core Workflow](/workflows/python-core-workflow/).
+
+## What you installed
+
+`import openquant` re-exports two different kinds of thing
+(`python/openquant/__init__.py`):
+
+| Attribute | Kind | Comes from |
+|---|---|---|
+| `risk`, `filters`, `sampling`, `labeling`, `bet_sizing`, `portfolio` | compiled | `openquant._core`, i.e. the Rust crate |
+| `bars`, `data`, `feature_diagnostics`, `pipeline`, `research`, `adapters`, `viz` | Python | `python/openquant/*.py` |
+
+Only the first row requires the compile step. That is why editing a file
+under `python/openquant/` takes effect immediately, while editing
+anything under `crates/` needs `maturin develop` re-run.
+
+Runtime dependencies are `polars>=1.0,<2` and `pyarrow>=15,<20`
+(`pyproject.toml`); `uv` installs them for you.
+
+## Next
+
+- [Python Core Workflow](/workflows/python-core-workflow/) — a runnable end-to-end research loop
+- [Troubleshooting](/setup/troubleshooting/) — when the compile step fails

--- a/docs-site/src/content/docs/setup/python-bindings.md
+++ b/docs-site/src/content/docs/setup/python-bindings.md
@@ -1,8 +1,7 @@
 ---
 title: Python Bindings Setup
 description: Baseline guidance for Python package workflow integration.
-status: validated
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/setup/python-bindings.md
+++ b/docs-site/src/content/docs/setup/python-bindings.md
@@ -2,6 +2,8 @@
 title: Python Bindings Setup
 description: Baseline guidance for Python package workflow integration.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/setup/troubleshooting.md
+++ b/docs-site/src/content/docs/setup/troubleshooting.md
@@ -1,9 +1,10 @@
 ---
 title: Troubleshooting
-description: Common first-run failures and known fixes.
-status: draft
+description: Symptom, cause and fix for the failures you actually hit building OpenQuant.
+status: reviewed
+last_validated: '2026-08-30'
 banner:
-  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
+  content: '<span class="doc-status doc-status--reviewed">Reviewed</span> A human has read this page end to end. It has not been verified line by line against the code.'
 audience:
   - quant-dev
   - platform-engineering
@@ -11,15 +12,289 @@ sidebar:
   order: 4
 ---
 
-## Slow test appears stalled
+Each entry is a symptom you can match against your terminal, the cause, and
+the fix. Entries marked **reproduced** were triggered and fixed on a real
+machine while writing this page; entries marked **not reproduced** are
+derived from reading the source or the CI configuration and have not been
+observed here. Believe the second kind less.
 
-- `test_sadf_test` is intentionally slow and should be run only via the explicit command in quickstart.
+## Rust toolchain and Python interpreter disagree on architecture
 
-## Docs link check failures
+**Symptom** — `maturin develop` dies almost immediately, while plain
+`cargo build` works fine:
 
-- Run `bun run build` before `bun run check:links`.
-- Confirm all internal links include `/openquant` base at build output level.
+```
+error[E0463]: can't find crate for `core`
+  |
+  = note: the `aarch64-apple-darwin` target may not be installed
+  = help: consider downloading the target with `rustup target add aarch64-apple-darwin`
+error: could not compile `cfg-if` (lib) due to 1 previous error
+💥 maturin failed
+  Caused by: Failed to build a native library through cargo
+```
 
-## API drift failures
+**Cause** — `maturin` builds for the architecture of the *Python
+interpreter*, not of your default Rust toolchain, so it passes
+`--target aarch64-apple-darwin` explicitly. If `rustup` was ever installed
+under Rosetta you have an `x86_64-apple-darwin` toolchain, which has no
+arm64 standard library. `cargo build` succeeds because it uses the host
+target and never crosses.
 
-- Re-run inventory generation from repo root and commit updated inventory if APIs changed intentionally.
+Confirm the mismatch:
+
+```bash
+rustup show | head -3        # "Default host: x86_64-apple-darwin"
+python3 -c "import platform; print(platform.machine())"   # "arm64"
+```
+
+**Fix** — add the missing standard library:
+
+```bash
+rustup target add aarch64-apple-darwin
+```
+
+That is enough; the x86_64 host toolchain cross-compiles to arm64 without
+further setup. To fix it properly, reinstall `rustup` natively (it will
+tell you to: `warn: Rustup is not running natively`).
+
+**Status: reproduced.** This is the error that blocked the first bindings
+build on the machine this page was written on, and `rustup target add`
+cleared it.
+
+## `uv sync` fails with an opaque `pep517 build-wheel` error
+
+**Symptom** —
+
+```
+Error: command ['maturin', 'pep517', 'build-wheel', '-i', '...', '--compatibility', 'off', '--editable']
+returned non-zero exit status 1
+hint: This usually indicates a problem with the package or the build environment.
+```
+
+**Cause** — this is almost never a `uv` problem. `uv sync` builds this
+project through `maturin`, and `uv` reports only maturin's exit status;
+the actual compiler error is further up in the output and easy to scroll
+past. In practice it is the architecture mismatch above, a missing linker,
+or a Rust compile error.
+
+**Fix** — capture the whole log and read upward from the bottom for the
+first `error[E...]` or `error:` line:
+
+```bash
+uv sync --group dev > sync.log 2>&1; grep -n "^error" sync.log | head
+```
+
+Then fix *that*, not the `uv` message. If you only want the bindings and
+not the full project environment, prefer the path CI uses, which reports
+compiler errors directly:
+
+```bash
+uv venv --python 3.11 .venv
+uv run --python .venv/bin/python --with maturin \
+  maturin develop --manifest-path crates/pyopenquant/Cargo.toml
+```
+
+**Status: reproduced.**
+
+## `maturin: command not found`
+
+**Symptom** — `just py-develop`, or a hand-run `maturin develop`, exits
+127.
+
+**Cause** — `maturin` is not a global tool in this project. It is a
+build-system requirement (`pyproject.toml`, `[build-system] requires`) and
+a dev dependency (`[dependency-groups] dev`). Nothing installs it onto
+your `PATH`.
+
+**Fix** — get it into the environment you are running from, either by
+materialising the dev group:
+
+```bash
+uv venv --python 3.11 .venv
+uv sync --group dev
+```
+
+or per-invocation, which is what `.github/workflows/python-bindings.yml`
+does:
+
+```bash
+uv run --python .venv/bin/python --with maturin \
+  maturin develop --manifest-path crates/pyopenquant/Cargo.toml
+```
+
+**Status: reproduced** (`maturin` is absent from `PATH` on a machine that
+has built this project successfully).
+
+## `import openquant` fails after a successful build
+
+**Symptom** — `maturin develop` reports success, then:
+
+```
+ModuleNotFoundError: No module named 'openquant'
+```
+
+or
+
+```
+ImportError: dynamic module does not define module export function (PyInit__core)
+```
+
+**Cause** — two different versions of the same mistake: the interpreter
+importing is not the interpreter the extension was built for. `maturin
+develop` installs into whichever environment it is *run inside*. The
+extension is stamped with a specific ABI —
+`PYO3_ENVIRONMENT_SIGNATURE="cpython-3.11-64bit"` appears in maturin's own
+cargo invocation — and CPython will not load a module built for a
+different minor version.
+
+**Fix** — always name the interpreter explicitly, on both sides. Every
+`just py-*` recipe does this for exactly this reason:
+
+```bash
+uv run --python .venv/bin/python python -c "import openquant, sys; print(sys.executable)"
+```
+
+If `sys.executable` is not the `.venv/bin/python` you built against,
+that is the bug. Rebuild with the interpreter you intend to use; a
+`.venv` recreated on a different Python minor version needs a rebuild,
+not just a re-install.
+
+**Status: not reproduced.** The reasoning is read off maturin's build
+environment and the `[lib] name = "_core"` / `module-name =
+"openquant._core"` wiring in `crates/pyopenquant/Cargo.toml` and
+`pyproject.toml`; the failure itself was not triggered here.
+
+## `linker 'cc' not found` (Linux)
+
+**Symptom** — every Rust build fails at the link step, no matter which
+crate.
+
+**Cause** — `rustc` shells out to the system C compiler to link. `rustup`
+installs neither.
+
+**Fix** —
+
+```bash
+sudo apt-get install -y build-essential      # Debian/Ubuntu
+sudo dnf groupinstall -y "Development Tools" # Fedora/RHEL
+```
+
+On macOS the equivalent is `xcode-select --install`.
+
+**Status: not reproduced** — this page was written on macOS, where the
+Command Line Tools were already present.
+
+## The build is killed, or the machine swaps to a halt
+
+**Symptom** — `cargo` or `maturin` output ends in `signal: 9, SIGKILL` or
+`Killed`, usually while compiling `polars`.
+
+**Cause** — this workspace depends on `polars 0.46` and `nalgebra 0.32`.
+Cargo compiles as many crates in parallel as you have cores, and several
+polars crates are individually memory-hungry. On a machine with less than
+about 2 GB of RAM per core, the peak overlaps and the OOM killer wins.
+
+**Fix** — trade wall-clock for memory:
+
+```bash
+cargo build -j 2                # or: export CARGO_BUILD_JOBS=2
+```
+
+`maturin` inherits `CARGO_BUILD_JOBS`, so export it before
+`maturin develop` rather than passing `-j` to maturin.
+
+**Status: not reproduced.** The dependency set is read from
+`crates/openquant/Cargo.toml`; the OOM was not induced here, and the
+2 GB-per-core figure is a rule of thumb, not a measurement.
+
+## Python runs out of memory building bars from a large dataset
+
+**Symptom** — `build_time_bars` / `build_volume_bars` /
+`build_dollar_bars` on a multi-million-row frame consumes far more memory
+than the frame itself, and may be killed.
+
+**Cause** — this is structural, not a leak. `openquant.bars` crosses the
+PyO3 boundary with plain Python objects. In
+`python/openquant/bars.py`, `_build_by_symbol` does, per symbol:
+
+```python
+rows = rust_builder(
+    [str(x) for x in sdf["ts"].to_list()],
+    [float(x) for x in sdf["close"].to_list()],
+    [float(x) for x in sdf["volume"].to_list()],
+    param,
+)
+```
+
+Three fully materialised Python lists go in — one of them a list of
+formatted timestamp *strings* — and a Python list of 9-tuples comes back,
+before any of it becomes a DataFrame. A Python `str` and `float` cost
+tens of bytes each in object overhead alone, so peak memory is a large
+multiple of the Arrow-backed frame you started from.
+
+**Fix** — do not hand the whole history to one call. The function already
+loops per symbol, so the remaining axis is time: slice with polars (which
+stays in Arrow memory) and concatenate the bar frames.
+
+```python
+import polars as pl
+from openquant import bars
+
+pieces = [
+    bars.build_dollar_bars(chunk, dollar_value_per_bar=5_000_000.0)
+    for chunk in df.sort("ts").iter_slices(2_000_000)
+]
+out = pl.concat(pieces, how="vertical").sort(["symbol", "ts"])
+```
+
+Choose the slice boundary on a date, not a row count, if you need bar
+edges to be exactly reproducible — a bar that straddles a chunk boundary
+will be split.
+
+**Status: not reproduced.** The memory characteristic is read directly
+from `python/openquant/bars.py`; no allocation profile was measured, and
+the 2-million-row slice above is a starting point rather than a tuned
+value.
+
+## The slow structural-break test looks stalled
+
+**Symptom** — `cargo test` sits on `test_sadf_test` for a long time.
+
+**Cause** — it is not stalled. The test is annotated in
+`crates/openquant/tests/structural_breaks.rs`:
+
+```rust
+#[ignore = "long-running hotspot; run explicitly with `cargo test -p openquant --test structural_breaks test_sadf_test -- --ignored`"]
+```
+
+It is excluded from the default run, so if you are seeing it you passed
+`--ignored` or `--include-ignored`.
+
+**Fix** — use the fast path for iteration and run the slow test
+deliberately:
+
+```bash
+cargo test --workspace --lib --tests --all-features -- --skip test_sadf_test
+cargo test -p openquant --test structural_breaks test_sadf_test -- --ignored
+```
+
+**Status: reproduced** (the `#[ignore]` annotation and its reason string
+are verbatim from the test file).
+
+## Docs-site gates
+
+Failures in `check:links`, `check:api-drift` and `check:content-schema`
+are maintainer gates, not first-run problems. They are documented where
+they are run, on [Local Build Setup](/setup/local-build/#when-a-gate-fails).
+
+## Still stuck
+
+Open an issue with the output of:
+
+```bash
+rustc --version && cargo --version && uv --version
+rustup show | head -5
+python3 -c "import platform, sys; print(platform.machine(), sys.version)"
+```
+
+The first three lines resolve most of the entries above on sight.

--- a/docs-site/src/content/docs/setup/troubleshooting.md
+++ b/docs-site/src/content/docs/setup/troubleshooting.md
@@ -1,8 +1,7 @@
 ---
 title: Troubleshooting
 description: Common first-run failures and known fixes.
-status: validated
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/setup/troubleshooting.md
+++ b/docs-site/src/content/docs/setup/troubleshooting.md
@@ -2,6 +2,8 @@
 title: Troubleshooting
 description: Common first-run failures and known fixes.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/workflows/notebook-research-workflow.md
+++ b/docs-site/src/content/docs/workflows/notebook-research-workflow.md
@@ -2,6 +2,8 @@
 title: Notebook Research Workflow
 description: Notebook-first research flow with promotion controls for institutional settings.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/workflows/notebook-research-workflow.md
+++ b/docs-site/src/content/docs/workflows/notebook-research-workflow.md
@@ -1,8 +1,7 @@
 ---
 title: Notebook Research Workflow
 description: Notebook-first research flow with promotion controls for institutional settings.
-status: in_review
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/workflows/python-core-workflow.md
+++ b/docs-site/src/content/docs/workflows/python-core-workflow.md
@@ -2,6 +2,8 @@
 title: Python Core Workflow
 description: Python-first workflow for ingestion, bars, diagnostics, and mid-frequency pipeline execution.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/workflows/python-core-workflow.md
+++ b/docs-site/src/content/docs/workflows/python-core-workflow.md
@@ -1,8 +1,7 @@
 ---
 title: Python Core Workflow
 description: Python-first workflow for ingestion, bars, diagnostics, and mid-frequency pipeline execution.
-status: validated
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/workflows/python-core-workflow.md
+++ b/docs-site/src/content/docs/workflows/python-core-workflow.md
@@ -1,9 +1,10 @@
 ---
 title: Python Core Workflow
-description: Python-first workflow for ingestion, bars, diagnostics, and mid-frequency pipeline execution.
-status: draft
+description: One runnable Python script from raw OHLCV to a promotion decision, with its output.
+status: reviewed
+last_validated: '2026-08-30'
 banner:
-  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
+  content: '<span class="doc-status doc-status--reviewed">Reviewed</span> A human has read this page end to end. It has not been verified line by line against the code.'
 audience:
   - quant-dev
   - platform-engineering
@@ -11,52 +12,220 @@ sidebar:
   order: 2
 ---
 
-## Workflow Objective
+The Python surface is a research loop, not a wrapper: it goes from a CSV
+to a *decision* — promote this candidate, or don't. This page is one
+script that runs the whole loop, and its actual output.
 
-Run the core research loop in Python while preserving OpenQuant's leakage and diagnostics standards.
+You need the bindings built first ([Python Bindings
+Setup](/setup/python-bindings/)). Run everything below from the
+repository root:
 
-## Stage 1: Ingestion and quality controls
+```bash
+uv run --python .venv/bin/python python workflow.py
+```
 
-Namespace: `openquant.data`
+For the namespace-by-namespace symbol list, see [API
+Surfaces](/module-reference/api-surfaces/). This page explains the loop
+rather than reprinting it.
 
-Primary APIs:
-- `load_ohlcv`
-- `clean_ohlcv`
-- `align_calendar`
-- `data_quality_report`
+## The script
 
-## Stage 2: Event-driven bars
+```python
+"""OpenQuant research loop: ingest -> bars -> pipeline -> costs -> decision."""
 
-Namespace: `openquant.bars`
+from openquant import bars, data, research
 
-Primary APIs:
-- `build_time_bars`
-- `build_tick_bars`
-- `build_volume_bars`
-- `build_dollar_bars`
+# --- Stage 1: ingest and clean -------------------------------------------
+frame, quality = data.load_ohlcv(
+    "python/tests/fixtures/ohlcv_us_equities.csv",
+    return_report=True,
+)
+print(f"stage 1  {frame.height} rows, {quality['symbol_count']} symbols, "
+      f"{quality['rows_removed_by_deduplication']} duplicate row(s) dropped")
+print(f"stage 1  columns: {frame.columns}")
 
-## Stage 3: Feature diagnostics
+# --- Stage 2: event-driven bars ------------------------------------------
+dollar_bars = bars.build_dollar_bars(frame, dollar_value_per_bar=1_000_000.0)
+print(f"stage 2  {dollar_bars.height} dollar bars")
+print(f"stage 2  diagnostics: {bars.bar_diagnostics(dollar_bars)}")
 
-Namespace: `openquant.feature_diagnostics`
+# --- Stages 3-4: the research loop ---------------------------------------
+# The fixture above is six rows; the loop needs a real series, so use the
+# deterministic synthetic generator for the rest.
+dataset = research.make_synthetic_futures_dataset(n_bars=480, seed=7)
+result = research.run_flywheel_iteration(dataset)
 
-Primary APIs:
-- `mdi_importance`
-- `mda_importance`
-- `sfi_importance`
-- `orthogonalize_features_pca`
-- `substitution_effect_report`
+print(f"stage 3  {len(result['events']['timestamps'])} CUSUM events")
+print(f"stage 3  leakage checks: {result['leakage_checks']}")
 
-## Stage 4: Pipeline execution and reporting
+risk = result["risk"]
+print(f"stage 4  realized_sharpe {risk['realized_sharpe']:+.4f}   "
+      f"VaR(5%) {risk['value_at_risk']:+.6f}   ES(5%) {risk['expected_shortfall']:+.6f}")
 
-Namespace: `openquant.pipeline`
+portfolio = result["portfolio"]
+weights = dict(zip(portfolio["asset_names"], (round(w, 3) for w in portfolio["weights"])))
+print(f"stage 4  weights {weights}   portfolio_sharpe {portfolio['portfolio_sharpe']:.4f}")
 
-Primary APIs:
-- `run_mid_frequency_pipeline`
-- `run_mid_frequency_pipeline_frames`
-- `summarize_pipeline`
+costs = result["costs"]
+print(f"stage 4  turnover {costs['turnover']:.2f}   cost {costs['estimated_total_cost']:.6f}")
+print(f"stage 4  gross {costs['gross_total_return']:+.6f} -> "
+      f"net {costs['net_total_return']:+.6f}   net_sharpe {costs['net_sharpe']:+.4f}")
 
-## Quality Criteria
+print("stage 4  promotion gates:")
+for gate, passed in result["promotion"].items():
+    print(f"           {gate:<26} {passed}")
+```
 
-- Feature diagnostics use leakage-safe validation defaults.
-- Report artifacts include trial and split metadata.
-- Results are reproducible from declared data and code revisions.
+## Output
+
+```text
+stage 1  5 rows, 2 symbols, 1 duplicate row(s) dropped
+stage 1  columns: ['ts', 'symbol', 'open', 'high', 'low', 'close', 'volume', 'adj_close']
+stage 2  4 dollar bars
+stage 2  diagnostics: {'n_bars': 4.0, 'lag1_return_autocorr': 0.0, 'lag1_sq_return_autocorr': 0.0, 'return_std': 0.0}
+stage 3  207 CUSUM events
+stage 3  leakage checks: {'inputs_aligned': True, 'event_indices_sorted': True, 'has_forward_look_bias': False}
+stage 4  realized_sharpe -0.3277   VaR(5%) -0.000201   ES(5%) -0.000330
+stage 4  weights {'CL': 0.403, 'NG': 0.471, 'RB': 0.043, 'GC': 0.082}   portfolio_sharpe 2.0040
+stage 4  turnover 9.40   cost 0.003441
+stage 4  gross -0.001254 -> net -0.004695   net_sharpe -0.2951
+stage 4  promotion gates:
+           passed_realized_sharpe     False
+           passed_net_sharpe          False
+           passed_alignment_guard     True
+           passed_event_order_guard   True
+           promote_candidate          False
+```
+
+Four things in that output are worth pausing on.
+
+**480 bars produced 207 events.** CUSUM at a 0.1% threshold fires on
+roughly 43% of bars here. On real data that ratio is your event-rate
+knob, and it trades statistical power against label overlap.
+
+**`portfolio_sharpe` 2.00 sits next to `realized_sharpe` -0.33.** These
+answer different questions and are not comparable. The first is the
+allocator's in-sample optimum across the four assets; the second is what
+the traded strategy returned. Confusing them is the easiest way to
+believe a dead strategy is alive.
+
+**Cost is larger than gross return.** `turnover` 9.4 × the per-turn
+charge gives 0.0034, against a gross return of -0.0013. The strategy was
+already losing; costs made it lose almost four times as much.
+
+**Both leakage guards passed and the candidate was still rejected.** The
+guards are necessary, not sufficient — they say the inputs were coherent,
+not that the result is good.
+
+## What each stage is doing, and why
+
+### Stage 1 — ingest, and get the report
+
+`load_ohlcv` does three things that matter before any modelling:
+canonicalises the header (`Date` → `ts`, `Ticker` → `symbol`, `Adj Close`
+→ `adj_close`, and about a dozen more aliases in `data.py`), sorts by
+symbol and timestamp, and de-duplicates — keeping the *last* row for a
+repeated `(symbol, ts)`, which is the right convention when a vendor
+restates a bar.
+
+Pass `return_report=True` whenever the data is not yours. The
+deduplication is silent otherwise, and a silently dropped restatement is
+how a look-ahead bug enters a backtest without anyone noticing.
+`data.data_quality_report(df)` gives you the same diagnostics for a frame
+you already hold, and `data.align_calendar(df, interval="1d")` fills the
+grid when you need one bar per period per symbol.
+
+### Stage 2 — bars sampled on activity
+
+`bars.build_dollar_bars` (and `build_tick_bars`, `build_volume_bars`)
+close a bar when a *quantity* threshold is met rather than when the clock
+advances. Dollar bars are usually the best default: they are the least
+sensitive to splits and to secular growth in share price, so bar
+statistics stay comparable over long histories.
+`bars.bar_diagnostics` reports the lag-1 autocorrelation you are trying
+to remove by sampling this way.
+
+:::caution[Memory]
+`bars` crosses the PyO3 boundary with plain Python lists — one of
+timestamp *strings* — so peak memory is a large multiple of the Arrow
+frame you started from. On multi-million-row inputs, slice first. See
+[Troubleshooting](/setup/troubleshooting/#python-runs-out-of-memory-building-bars-from-a-large-dataset).
+:::
+
+### Stage 3 — the pipeline, and its leakage checks
+
+`run_mid_frequency_pipeline_frames` runs CUSUM sampling → labeling →
+bet sizing → backtest → portfolio and risk in one call, returning nested
+dicts under `events`, `signals`, `portfolio`, `risk`, `backtest`,
+`leakage_checks`, plus polars frames under `frames`. The `_frames`
+variant is the one to use interactively;
+`run_mid_frequency_pipeline` returns the same content without the
+DataFrames.
+
+Read `leakage_checks` before you read anything else. `inputs_aligned`
+and `event_indices_sorted` are the pipeline stating that it was handed
+coherent inputs. A Sharpe computed on top of a failed alignment check is
+not a number, and every gate in `promotion` below depends on these two
+passing.
+
+The parameters worth knowing:
+
+| Parameter | Default | Effect |
+|---|---|---|
+| `cusum_threshold` | `0.001` | Event rate. Lower gives more events and more overlap. |
+| `num_classes` | `2` | The null probability `get_signal` tests against, `1/num_classes`. |
+| `step_size` | `0.1` | Position quantisation. Larger suppresses churn at the cost of tracking. |
+| `risk_free_rate` | `0.0` | Sharpe numerator offset. |
+| `confidence_level` | `0.05` | Tail level for VaR, ES and CDaR. |
+
+### Stage 4 — costs, and the promotion decision
+
+This is what separates `research.run_flywheel_iteration` from calling the
+pipeline directly: it charges the strategy for trading.
+
+`costs` is built from turnover times a per-turn cost of commission +
+spread + a volatility-scaled slippage term (`commission_bps` 1.5,
+`spread_bps` 2.0, `slippage_vol_mult` 8.0 by default). `net_sharpe` is
+recomputed after that charge. Gross and net will differ, sometimes by
+enough to change the sign of the decision — which is the point.
+
+`promotion` is then four boolean gates, all of which must hold for
+`promote_candidate`:
+
+| Gate | Passes when |
+|---|---|
+| `passed_realized_sharpe` | realised Sharpe ≥ `min_realized_sharpe` (0.25) |
+| `passed_net_sharpe` | net-of-cost Sharpe ≥ `min_net_sharpe` (0.30) |
+| `passed_alignment_guard` | `leakage_checks["inputs_aligned"]` |
+| `passed_event_order_guard` | `leakage_checks["event_indices_sorted"]` |
+
+Two of the four are leakage guards, not performance thresholds. A
+candidate cannot be promoted on returns alone.
+
+### Feature diagnostics, before you trust any of it
+
+`openquant.feature_diagnostics` is the part most easily misused, so it is
+worth naming what each function answers:
+
+- `mdi_importance` — in-sample, computed from the fitted model. Cheap,
+  and biased toward high-cardinality features.
+- `mda_importance` — out-of-sample, by permutation. Takes
+  `event_end_indices` (plus `n_splits`, `pct_embargo`) and builds *purged*
+  splits from them. This is the one to trust when the two disagree — but
+  only if you actually pass `event_end_indices`; the default builds
+  degenerate one-row intervals and purges nothing.
+- `sfi_importance` — one feature at a time, so it is the only one immune
+  to the substitution effect. Also purged; also slow, since it refits per
+  feature.
+- `substitution_effect_report` — tells you when correlated features are
+  splitting credit and making all three of the above look flat.
+- `orthogonalize_features_pca` — the usual response to that report.
+
+MDI and MDA routinely rank features differently. That is information
+about your features, not a bug.
+
+## Where to go next
+
+- [Rust Core Workflow](/workflows/rust-core-workflow/) — the same ground in Rust
+- [Examples Catalog](/examples/catalog/) — runnable examples that ship in the repo
+- [API Surfaces](/module-reference/api-surfaces/) — the full symbol lists

--- a/docs-site/src/content/docs/workflows/rust-core-workflow.md
+++ b/docs-site/src/content/docs/workflows/rust-core-workflow.md
@@ -2,6 +2,8 @@
 title: Rust Core Workflow
 description: Canonical Rust workflow from event sampling to portfolio/risk diagnostics.
 status: draft
+banner:
+  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/workflows/rust-core-workflow.md
+++ b/docs-site/src/content/docs/workflows/rust-core-workflow.md
@@ -1,8 +1,7 @@
 ---
 title: Rust Core Workflow
 description: Canonical Rust workflow from event sampling to portfolio/risk diagnostics.
-status: validated
-last_validated: '2026-03-02'
+status: draft
 audience:
   - quant-dev
   - platform-engineering

--- a/docs-site/src/content/docs/workflows/rust-core-workflow.md
+++ b/docs-site/src/content/docs/workflows/rust-core-workflow.md
@@ -1,9 +1,10 @@
 ---
 title: Rust Core Workflow
-description: Canonical Rust workflow from event sampling to portfolio/risk diagnostics.
-status: draft
+description: One runnable Rust program from event sampling to portfolio risk, with its output.
+status: reviewed
+last_validated: '2026-08-30'
 banner:
-  content: '<span class="doc-status doc-status--draft">Draft</span> This page is known to be incomplete. Treat its contents as provisional.'
+  content: '<span class="doc-status doc-status--reviewed">Reviewed</span> A human has read this page end to end. It has not been verified line by line against the code.'
 audience:
   - quant-dev
   - platform-engineering
@@ -19,55 +20,290 @@ sidebar:
   order: 1
 ---
 
-## Workflow Objective
+The AFML pipeline is five stages, and the interesting part is how they
+constrain each other: how you sample events decides what a label can
+mean, and how labels overlap in time decides whether your validation is
+honest. This page is one program that threads all five, and its actual
+output.
 
-Produce leakage-aware model evaluation and portfolio diagnostics using the Rust library API surface.
+Save it as `crates/openquant/examples/afml_workflow.rs` and run:
 
-## Stage 1: Data structures and event filters
+```bash
+cargo run -p openquant --example afml_workflow
+```
 
-Modules:
-- `data_structures`
-- `filters`
+That is the command used to produce the output below. Add `--release` if
+you want it fast; the first build of either profile compiles `polars` and
+`nalgebra` and takes a while.
 
-Deliverable:
-- event-based bars and filtered timestamps ready for labeling.
+## The program
 
-## Stage 2: Label engineering and sizing
+```rust
+//! End-to-end AFML workflow: sampling -> labeling -> sizing -> purged CV -> risk.
+use chrono::{Duration, NaiveDate, NaiveDateTime};
+use nalgebra::DMatrix;
+use openquant::backtest_statistics::sharpe_ratio;
+use openquant::bet_sizing::{discrete_signal, get_signal};
+use openquant::cross_validation::PurgedKFold;
+use openquant::filters::{cusum_filter_indices, Threshold};
+use openquant::labeling::{
+    add_vertical_barrier, triple_barrier_events, triple_barrier_labels, TripleBarrierConfig,
+};
+use openquant::portfolio_optimization::allocate_max_sharpe;
+use openquant::risk_metrics::RiskMetrics;
 
-Modules:
-- `labeling`
-- `bet_sizing`
+const N_BARS: usize = 480;
+const N_ASSETS: usize = 4;
 
-Deliverable:
-- event labels and executable sizing signals with explicit barriers and constraints.
+/// Deterministic synthetic minute bars. No RNG, so the printed numbers below
+/// are reproducible on any machine.
+fn synthetic_series() -> (Vec<NaiveDateTime>, Vec<f64>) {
+    let start = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap().and_hms_opt(9, 30, 0).unwrap();
+    let mut ts = Vec::with_capacity(N_BARS);
+    let mut close = Vec::with_capacity(N_BARS);
+    for i in 0..N_BARS {
+        let x = i as f64;
+        ts.push(start + Duration::minutes(i as i64));
+        close.push(80.0 + 0.004 * x + 0.45 * (x / 9.0).sin() + 0.25 * (x / 37.0).sin());
+    }
+    (ts, close)
+}
 
-## Stage 3: Leakage-safe validation and backtesting
+fn main() {
+    let (ts, close) = synthetic_series();
+    let bars: Vec<(NaiveDateTime, f64)> = ts.iter().copied().zip(close.iter().copied()).collect();
 
-Modules:
-- `cross_validation`
-- `backtesting_engine`
+    // ---- Stage 1: event sampling -------------------------------------------
+    // Sample on cumulative 0.1% moves instead of on the clock, so every event
+    // carries comparable information (AFML ch. 2/3).
+    let event_idx = cusum_filter_indices(&close, Threshold::Scalar(0.001));
+    let t_events: Vec<NaiveDateTime> = event_idx.iter().map(|&i| ts[i]).collect();
+    println!("stage 1  {:>4} bars -> {:>3} CUSUM events", N_BARS, t_events.len());
 
-Deliverable:
-- Purged/embargoed validation plus CPCV-aware distributional diagnostics.
+    // ---- Stage 2: triple-barrier labels + bet sizing ------------------------
+    // Barrier width is a multiple of a per-event volatility target, so profit
+    // taking and stop loss scale with the regime rather than being fixed ticks.
+    let window = 20usize;
+    let target: Vec<(NaiveDateTime, f64)> = (0..N_BARS)
+        .map(|i| {
+            let lo = i.saturating_sub(window);
+            let rets: Vec<f64> =
+                (lo + 1..=i).map(|k| close[k] / close[k - 1] - 1.0).collect();
+            let n = rets.len().max(1) as f64;
+            let mean = rets.iter().sum::<f64>() / n;
+            let var = rets.iter().map(|r| (r - mean).powi(2)).sum::<f64>() / n;
+            (ts[i], var.sqrt().max(1e-4))
+        })
+        .collect();
 
-## Stage 4: Risk and portfolio diagnostics
+    let vbars = add_vertical_barrier(&t_events, &bars, 0, 0, 45, 0);
+    let cfg = TripleBarrierConfig {
+        pt: 1.0,                              // profit-take barrier = 1.0 x target vol
+        sl: 1.0,                              // stop-loss barrier  = 1.0 x target vol
+        min_ret: 0.0002,                      // skip events too small to trade
+        vertical_barrier_times: Some(&vbars), // 45-minute holding-period cap
+    };
+    let events = triple_barrier_events(&bars, &t_events, &target, cfg, None);
+    let labeled = triple_barrier_labels(&events, &bars);
+    let wins = labeled.iter().filter(|l| l.label > 0).count();
+    println!(
+        "stage 2  {:>3} labeled events, {:>3} positive ({:.0}%)",
+        labeled.len(),
+        wins,
+        100.0 * wins as f64 / labeled.len().max(1) as f64
+    );
 
-Modules:
-- `backtest_statistics`
-- `risk_metrics`
-- `strategy_risk`
-- `portfolio_optimization`, `hrp`, `hcaa`, `onc`, `cla`
+    // A real model goes here. We stand in a calibrated-probability vector so the
+    // sizing stage has something to consume; `get_signal` maps p -> [-1, 1] via
+    // a z-test against 1/num_classes, and `discrete_signal` quantises to
+    // tradable steps to suppress churn.
+    let probs: Vec<f64> = (0..labeled.len())
+        .map(|i| 0.5 + 0.18 * ((i as f64) / 7.0).sin())
+        .collect();
+    let raw = get_signal(&probs, 2, None);
+    let sized = discrete_signal(&raw, 0.25);
+    println!(
+        "stage 3  sizes in [{:.2}, {:.2}], {} distinct steps",
+        sized.iter().cloned().fold(f64::INFINITY, f64::min),
+        sized.iter().cloned().fold(f64::NEG_INFINITY, f64::max),
+        {
+            let mut v: Vec<i64> = sized.iter().map(|s| (s * 100.0).round() as i64).collect();
+            v.sort_unstable();
+            v.dedup();
+            v.len()
+        }
+    );
 
-Deliverable:
-- risk-adjusted strategy diagnostics and portfolio allocation outputs.
+    // ---- Stage 4: purged, embargoed cross-validation ------------------------
+    // Labels overlap in time, so a plain K-fold leaks: a training label whose
+    // barrier closes inside the test window has already seen the test outcome.
+    // PurgedKFold drops those, then embargoes a fraction after each test fold.
+    let info_sets: Vec<(NaiveDateTime, NaiveDateTime)> = events
+        .iter()
+        .map(|(t0, ev)| (*t0, ev.t1.unwrap_or(*t0)))
+        .collect();
+    let cv = PurgedKFold::new(5, info_sets.clone(), 0.01).expect("purged kfold");
+    let splits = cv.split(info_sets.len()).expect("split");
+    let naive_train = info_sets.len() - info_sets.len() / 5;
+    println!(
+        "stage 4  5 folds, embargo 1%: train {} -> {} rows ({} purged by overlap)",
+        naive_train,
+        splits[0].0.len(),
+        naive_train - splits[0].0.len()
+    );
 
-## Quality Criteria
+    // ---- Stage 5: strategy risk and portfolio allocation --------------------
+    let strat_returns: Vec<f64> =
+        labeled.iter().zip(sized.iter()).map(|(l, s)| l.ret * s).collect();
+    let sr = sharpe_ratio(&strat_returns, 252.0 * 390.0, 0.0);
+    let rm = RiskMetrics;
+    let var = rm.calculate_value_at_risk(&strat_returns, 0.05).expect("var");
+    let es = rm.calculate_expected_shortfall(&strat_returns, 0.05).expect("es");
+    println!("stage 5  sharpe {:+.3}   VaR(5%) {:+.5}   ES(5%) {:+.5}", sr, var, es);
 
-- Purging/embargo parameters explicitly documented.
-- Multiple-testing context included when reporting Sharpe-family metrics.
-- Portfolio-risk and strategy-failure-risk interpretations separated.
+    let mut px = Vec::with_capacity(N_BARS * N_ASSETS);
+    for i in 0..N_BARS {
+        for j in 0..N_ASSETS {
+            let lag = i.saturating_sub(j + 1);
+            px.push(close[lag] * (1.0 + 0.0015 * j as f64)
+                + (0.45 + 0.07 * j as f64) * ((i + 3 * j) as f64 / (9.5 + j as f64)).sin());
+        }
+    }
+    let prices = DMatrix::from_row_slice(N_BARS, N_ASSETS, &px);
+    let alloc = allocate_max_sharpe(&prices, 0.0, None, None).expect("max sharpe");
+    println!(
+        "stage 5  weights {:?}  portfolio sharpe {:.3}",
+        alloc.weights.iter().map(|w| (w * 1000.0).round() / 1000.0).collect::<Vec<_>>(),
+        alloc.portfolio_sharpe
+    );
+}
+```
 
-## Module Deep Links
+## Output
 
-- [Module Reference Index](/modules/)
-- [API Surfaces](/module-reference/api-surfaces/)
+```text
+stage 1   480 bars -> 147 CUSUM events
+stage 2  106 labeled events,  57 positive (54%)
+stage 3  sizes in [-0.25, 0.25], 3 distinct steps
+stage 4  5 folds, embargo 1%: train 85 -> 82 rows (3 purged by overlap)
+stage 5  sharpe +47.975   VaR(5%) -0.00015   ES(5%) -0.00016
+stage 5  weights [0.262, 0.415, 0.0, 0.324]  portfolio sharpe 27.548
+```
+
+:::caution[Those Sharpe numbers are nonsense, and that is the point]
+`sharpe +47.975` is not a result. The synthetic series is a sum of two
+sine waves with no noise term, so it is very nearly deterministic, and
+the program annualises by `sqrt(252 × 390)` ≈ 313. A near-riskless series
+divided by a near-zero standard deviation and multiplied by 313 produces
+exactly this.
+
+The numbers to actually read on this run are the structural ones — 480
+bars gave 147 events, 106 of which cleared `min_ret` and got labels, and
+purging removed 3 of 85 training rows. Those describe the pipeline. The
+Sharpe describes the toy.
+
+If a real dataset ever hands you a number like this, the first thing to
+check is your `entries_per_year`, and the second is whether your returns
+series has any variance in it.
+:::
+
+## What each stage is doing, and why
+
+### Stage 1 — sample on information, not on the clock
+
+`cusum_filter_indices` accumulates signed returns and fires when the
+running sum breaches a threshold, resetting on each event. Time bars
+give you many uninformative observations in quiet periods and too few in
+active ones; CUSUM events arrive at a rate set by the market. Everything
+downstream inherits this: a label is a statement about *an event*, so
+sampling badly is not something later stages can repair.
+
+`Threshold::Scalar(0.001)` is a flat 0.1%. `Threshold::Dynamic(Vec<f64>)`
+takes a per-bar threshold if you want to scale it by a volatility
+estimate, which is usually the better choice on real data.
+
+### Stage 2 — label with barriers scaled to volatility
+
+`triple_barrier_events` places three barriers around each event: a
+profit-take at `pt × target`, a stop-loss at `sl × target`, and a
+vertical (time) barrier. `target` is per-event, so a 1.0 multiplier means
+"one unit of that event's own volatility" rather than a fixed number of
+ticks — the same configuration stays meaningful across regimes.
+
+The three knobs and what they cost you:
+
+| Field | In the program | What moving it does |
+|---|---|---|
+| `pt` / `sl` | `1.0` / `1.0` | Symmetric barriers. Asymmetry here is a directional prior; make it deliberately, not by accident. |
+| `min_ret` | `0.0002` | Events whose target is below this are dropped as untradeable. Raising it discards more events; each one you keep must clear costs. |
+| `vertical_barrier_times` | 45 minutes | The holding-period cap. This is what bounds label overlap, and therefore how much stage 4 has to purge. |
+
+`triple_barrier_labels` then returns `{-1, 0, 1}` labels. Pass
+`side_prediction` to `triple_barrier_events` instead and the regime
+becomes `{0, 1}` — meta-labeling, where the label answers "should I take
+the bet my primary model proposed?" rather than "which way does it go?".
+
+### Stage 3 — turn probabilities into positions
+
+`get_signal` maps a calibrated probability to a size in `[-1, 1]` by a
+z-test against `1/num_classes`, so a probability barely above chance
+produces a size near zero rather than a full-size bet.
+`discrete_signal(&raw, 0.25)` then quantises to steps of 0.25. That is
+not cosmetic: without it, a signal that drifts by 0.01 produces a trade,
+and turnover — not gross return — is what a mid-frequency strategy
+usually dies of.
+
+### Stage 4 — purge and embargo, or your validation lies
+
+This is the stage the rest of the library exists to make possible.
+
+Triple-barrier labels **overlap in time**: a label starting at 10:00 with
+a 45-minute vertical barrier is still open at 10:30. Under plain K-fold,
+that 10:00 training label has already observed the outcome of a 10:30
+test event. The model does not need to generalise; it can recall.
+
+`PurgedKFold::new(n_splits, samples_info_sets, pct_embargo)` takes the
+`(start, end)` interval of every label — that is what `samples_info_sets`
+is — and drops from each training fold every label whose interval
+overlaps the test fold. It then embargoes a further `pct_embargo`
+fraction of samples after the test window, because serial correlation
+leaks across an exact boundary even without overlap.
+
+:::caution
+`PurgedKFold::new` takes **three** arguments, and the middle one is the
+interval list, not a number. The `PurgedKFold::new(5, 0.01)` form that
+appears on some module pages does not compile. `pct_embargo` is the
+third argument; `0.01` means 1% of the sample count.
+:::
+
+The stage 4 line is the point: `train 85 -> 82 rows (3 purged by
+overlap)`. The purge removes real training rows. If your purged and
+unpurged fold sizes come out identical, your labels do not overlap — and
+with a vertical barrier set, that is worth checking rather than
+celebrating.
+
+### Stage 5 — separate strategy risk from portfolio risk
+
+`sharpe_ratio(&returns, entries_per_year, risk_free_rate)` annualises by
+`sqrt(entries_per_year)`. The program passes `252.0 * 390.0` because the
+synthetic series is minute bars; passing the wrong figure here is the
+easiest way to report a Sharpe that is off by an order of magnitude.
+
+`RiskMetrics` covers the loss tail — `calculate_value_at_risk`,
+`calculate_expected_shortfall`, `calculate_conditional_drawdown_risk` —
+and answers "how bad is a bad day for this return stream".
+`allocate_max_sharpe` answers a different question: how to weight several
+assets. Do not read one as the other. A well-diversified allocation with
+a broken strategy is still broken.
+
+A Sharpe from a single backtest is also not evidence on its own. When you
+report one, report how many configurations you tried to get it —
+`backtest_statistics::deflated_sharpe_ratio` and
+`probabilistic_sharpe_ratio` exist for that, and
+`minimum_track_record_length` tells you how much data the claim needs.
+
+## Where to go next
+
+- [Python Core Workflow](/workflows/python-core-workflow/) — the same ground in Python
+- [Modules by AFML chapter](/module-reference/by-afml-chapter/) — the module behind each stage
+- [API Surfaces](/module-reference/api-surfaces/) — the full Rust and Python symbol lists

--- a/docs-site/src/styles/starlight.css
+++ b/docs-site/src/styles/starlight.css
@@ -229,3 +229,16 @@ h1 {
   font-family: var(--sl-font-mono);
   font-size: 0.92em;
 }
+
+/* The landing page shares its banner between the status badge and a call to
+   action, so links there take the status colours rather than the gradient
+   banner's near-white. */
+.sl-banner:has(.doc-status) a {
+  color: var(--doc-status-fg) !important;
+  text-decoration: underline !important;
+  text-underline-offset: 0.2em;
+}
+
+.sl-banner:has(.doc-status) a:hover {
+  color: var(--doc-status-pill) !important;
+}

--- a/docs-site/src/styles/starlight.css
+++ b/docs-site/src/styles/starlight.css
@@ -145,3 +145,87 @@ h1 {
 .pagination-links a {
   border-radius: 10px;
 }
+
+/* ── Page status badge ───────────────────────────────────────────────────────
+   Every doc page declares a `status` in its frontmatter and renders it through
+   the Starlight banner slot, so a reader can always tell whether a page was
+   machine-generated, is an unfinished draft, or has actually been read by a
+   human. Wired through `banner.content` rather than a Starlight component
+   override, because an override has to be registered in astro.config.mjs and
+   this branch does not own that file. check-content-schema.mjs enforces that
+   the badge matches the frontmatter status, so the two cannot drift.
+   The `:has()` guard keeps the site-wide banner gradient above intact for any
+   non-status banner. */
+.sl-banner:has(.doc-status) {
+  background: var(--doc-status-bg) !important;
+  color: var(--doc-status-fg) !important;
+  border-bottom: 1px solid var(--doc-status-border) !important;
+  font-size: var(--sl-text-sm);
+  font-weight: 500;
+  text-wrap: balance;
+}
+
+.sl-banner:has(.doc-status--generated) {
+  --doc-status-bg: #e7edf5;
+  --doc-status-fg: #2c3f55;
+  --doc-status-border: #c9d8e8;
+  --doc-status-pill: #5c728c;
+}
+
+.sl-banner:has(.doc-status--draft) {
+  --doc-status-bg: #fdf1dc;
+  --doc-status-fg: #5a4209;
+  --doc-status-border: #ecd39a;
+  --doc-status-pill: #a8760d;
+}
+
+.sl-banner:has(.doc-status--reviewed) {
+  --doc-status-bg: #e3f1e7;
+  --doc-status-fg: #1d4429;
+  --doc-status-border: #b7ddc3;
+  --doc-status-pill: #2f7d4a;
+}
+
+:root[data-theme='dark'] .sl-banner:has(.doc-status--generated) {
+  --doc-status-bg: #1a2536;
+  --doc-status-fg: #c3d3e6;
+  --doc-status-border: #294156;
+  --doc-status-pill: #55708f;
+}
+
+:root[data-theme='dark'] .sl-banner:has(.doc-status--draft) {
+  --doc-status-bg: #2e2716;
+  --doc-status-fg: #ecd7a4;
+  --doc-status-border: #4d3f1d;
+  --doc-status-pill: #a8790f;
+}
+
+:root[data-theme='dark'] .sl-banner:has(.doc-status--reviewed) {
+  --doc-status-bg: #16301f;
+  --doc-status-fg: #b9dcc5;
+  --doc-status-border: #27563a;
+  --doc-status-pill: #2f7d4a;
+}
+
+.doc-status {
+  display: inline-block;
+  margin-right: 0.5rem;
+  padding: 0.08rem 0.55rem;
+  border-radius: 999px;
+  background: var(--doc-status-pill);
+  color: #ffffff;
+  font-family: var(--sl-font-mono);
+  font-size: 0.72em;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  vertical-align: 0.1em;
+}
+
+.sl-banner:has(.doc-status) code {
+  padding: 0.05rem 0.3rem;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--doc-status-fg) 12%, transparent);
+  font-family: var(--sl-font-mono);
+  font-size: 0.92em;
+}


### PR DESCRIPTION
Stacked on #18 — merge that first; this targets its branch.

## Why

Eight hand-written pages promised something and delivered nothing. `setup/python-bindings.md` was
titled Setup, contained no setup step, and its "validation command" was a `cargo test` — which
**blocked `quickstart.md` Step 5**, whose Python code had no install path. `workflows/rust-core-workflow.md`
was a *canonical Rust workflow* containing zero lines of Rust.

## Verified by execution, not assertion

This is the part that matters, because the root cause of this whole project's doc problem is
documentation nobody ever ran:

- Built the PyO3 extension (`maturin develop`), confirmed `import openquant` works
- `pytest python/tests -q` → **32 passed**
- **Both workflow programs were run** — the output on the pages is their real output
- The Rust program passes `cargo check` with zero warnings

## Result

| Page | Before | After |
|---|---|---|
| `setup/prerequisites.md` | 54 w | 758 w |
| `setup/python-bindings.md` | 71 w | 634 w |
| `setup/troubleshooting.md` | 89 w | 1483 w |
| `quickstart.md` | — | 764 w |
| `workflows/rust-core-workflow.md` | 196 w | 1888 w |
| `workflows/python-core-workflow.md` | 146 w | 1334 w |
| `examples/catalog.md` | 56 w | 618 w |
| `coverage.md` | 102 w | 751 w |

## Findings turned up while verifying

1. **The old quickstart asserted `'promote_candidate': True`** in its Step 5 comment. The real value
   for that exact call is **False**, with both Sharpe gates failing. Fixed, with the true output shown.
2. **`mda_importance(..., event_end_indices=None)` purges nothing** — the default builds degenerate
   one-row intervals that never overlap. A purged-looking API doing no purging. Tracked separately;
   this is a code defect, not a docs one.

## Status frontmatter

Six pages promoted `draft` → `reviewed`. **`examples/catalog` and `coverage` deliberately left
`draft`**, each saying on the page why. **Nothing promoted to `validated`** — verifying that a page's
commands run is not the same as verifying it against the code.

## Keep-or-delete call on the last two

Both **kept and rewritten** rather than deleted. Deleting either needs an `astro.config.mjs` edit
that was outside this branch's surface: `catalog.md` is the only page in the `examples` autogenerate
sidebar group *and* the target of the `/examples` redirect; `coverage` is a hardcoded sidebar link.
Removing them from `src/content/docs/` alone would have shipped broken navigation. The clean
three-line deletion path is in the report if you would rather cut them.

## Verification

`astro build` 0 (99 pages / 111 HTML) · `check-content-schema` 0 · `check-links` 0. Independently
re-verified. `check:api-drift` is unaffected here — no `crates/` or `python/` source was touched.