### PR TITLE
fix: correct the get_parkinson_vol spelling in the public API

### DIFF
--- a/crates/openquant/src/util/volatility.rs
+++ b/crates/openquant/src/util/volatility.rs
@@ -48,8 +48,9 @@ pub fn get_daily_vol(close: &[(NaiveDateTime, f64)], lookback: usize) -> Vec<(Na
 }
 
 /// Parkinson volatility estimator.
-/// Mirrors mlfinlab.util.volatility.get_parksinson_vol.
-pub fn get_parksinson_vol(high: &[f64], low: &[f64], window: usize) -> Vec<f64> {
+/// Mirrors mlfinlab's `get_parksinson_vol` — note that upstream misspells
+/// "Parkinson"; this crate spells it correctly.
+pub fn get_parkinson_vol(high: &[f64], low: &[f64], window: usize) -> Vec<f64> {
     assert_eq!(high.len(), low.len(), "high/low length mismatch");
     let estimator: Vec<f64> = high
         .iter()

--- a/crates/openquant/tests/volatility_features.rs
+++ b/crates/openquant/tests/volatility_features.rs
@@ -1,5 +1,5 @@
 use csv::ReaderBuilder;
-use openquant::util::volatility::{get_garman_class_vol, get_parksinson_vol, get_yang_zhang_vol};
+use openquant::util::volatility::{get_garman_class_vol, get_parkinson_vol, get_yang_zhang_vol};
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
@@ -47,7 +47,7 @@ fn test_volatility_estimators_match_mlfinlab_baseline() {
     let (open, high, low, close) = load_ohlc();
     let gm_vol = get_garman_class_vol(&open, &high, &low, &close, 20);
     let yz_vol = get_yang_zhang_vol(&open, &high, &low, &close, 20);
-    let park_vol = get_parksinson_vol(&high, &low, 20);
+    let park_vol = get_parkinson_vol(&high, &low, 20);
 
     assert_eq!(close.len(), gm_vol.len());
     assert_eq!(close.len(), yz_vol.len());

--- a/crates/pyopenquant/src/volatility.rs
+++ b/crates/pyopenquant/src/volatility.rs
@@ -14,9 +14,9 @@ fn volatility_get_daily_vol(
     Ok(result.into_iter().map(|(ts, v)| (ts.format("%Y-%m-%d %H:%M:%S").to_string(), v)).collect())
 }
 
-#[pyfunction(name = "get_parksinson_vol")]
-fn volatility_get_parksinson_vol(high: Vec<f64>, low: Vec<f64>, window: usize) -> Vec<f64> {
-    openquant::util::volatility::get_parksinson_vol(&high, &low, window)
+#[pyfunction(name = "get_parkinson_vol")]
+fn volatility_get_parkinson_vol(high: Vec<f64>, low: Vec<f64>, window: usize) -> Vec<f64> {
+    openquant::util::volatility::get_parkinson_vol(&high, &low, window)
 }
 
 #[pyfunction(name = "get_garman_class_vol")]
@@ -44,7 +44,7 @@ fn volatility_get_yang_zhang_vol(
 pub fn register(py: Python<'_>, parent: &Bound<'_, PyModule>) -> PyResult<()> {
     let m = PyModule::new(py, "volatility")?;
     m.add_function(wrap_pyfunction!(volatility_get_daily_vol, &m)?)?;
-    m.add_function(wrap_pyfunction!(volatility_get_parksinson_vol, &m)?)?;
+    m.add_function(wrap_pyfunction!(volatility_get_parkinson_vol, &m)?)?;
     m.add_function(wrap_pyfunction!(volatility_get_garman_class_vol, &m)?)?;
     m.add_function(wrap_pyfunction!(volatility_get_yang_zhang_vol, &m)?)?;
     parent.add_submodule(&m)?;


### PR DESCRIPTION
Replaces #23, which GitHub auto-closed when its base branch (`chore/cargo-fmt-pyopenquant`, now merged as #20) was deleted. Same commit, retargeted to `main`.

**Breaking change, made on the owner's instruction.**

`Parkinson` was spelled `parksinson` in both the Rust function and the Python binding. Because
`#[pyfunction(name = "get_parksinson_vol")]` *is* the public Python API, correcting it breaks
downstream callers — which is why it was raised before being fixed.

Renamed:
- `openquant::util::volatility::get_parksinson_vol` → `get_parkinson_vol`
- the `pyopenquant` wrapper fn, its `#[pyfunction(name = …)]`, and its module registration
- `crates/openquant/tests/volatility_features.rs`

## One thing deliberately left misspelled

The doc comment still names **mlfinlab's** `get_parksinson_vol`, because that misspelling is
upstream's and is where ours came from. It now says so rather than propagating it silently.

## Verification

`cargo fmt -- --check` → 0 · `cargo test --package openquant --test volatility_features` → 0 (1 passed) ·
`cargo check --package pyopenquant` → 0

## Follow-up

`moduleDocs.ts` and the generated `modules/util-volatility.md` still carry the old name in four
places. Not fixed here — this branch carries the pre-#18 page generator, so regenerating from it
would revert the honest-status work. Tracked; #21's `check:examples` gate will fail loudly until it
is done, which is correct.