### PR TITLE
fix: make unpurged feature-importance CV impossible to get silently

### DIFF
--- a/docs-site/src/content/docs/modules/feature-diagnostics.md
+++ b/docs-site/src/content/docs/modules/feature-diagnostics.md
@@ -77,9 +77,22 @@ X = [[0.1, 0.5, 0.3], [0.2, 0.4, 0.1], ...]  # n_samples × n_features
 y = [1.0, 0.0, 1.0, ...]  # binary labels
 names = ["momentum", "volatility", "spread"]
 
+# event_end_indices[i] is the row at which sample i's label resolves. It is
+# REQUIRED for the purged methods: without it every sample would be a
+# degenerate one-row interval, nothing would be purged, and the training
+# folds would leak label information from the test fold. Passing it is what
+# makes the split actually purged.
+ends = [i + 3 for i in range(len(y))]
+
 mdi = mdi_importance(X, y, feature_names=names, n_estimators=32)
-mda = mda_importance(X, y, feature_names=names, n_splits=5, pct_embargo=0.01)
-sfi = sfi_importance(X, y, feature_names=names, n_splits=5)
+mda = mda_importance(X, y, feature_names=names, event_end_indices=ends,
+                     n_splits=5, pct_embargo=0.01)
+sfi = sfi_importance(X, y, feature_names=names, event_end_indices=ends,
+                     n_splits=5)
+
+# mda["cv"]["purged"] is True here. It is False -- and "method" reads
+# "kfold_embargo_only" -- if you deliberately opt out with
+# allow_unpurged=True, so an unpurged run can never look like a purged one.
 
 # Each returns: {"table": pl.DataFrame, "viz_payload": {...}, ...}
 print(mdi["table"])  # feature | mean | std | stderr

--- a/docs-site/src/content/docs/workflows/python-core-workflow.md
+++ b/docs-site/src/content/docs/workflows/python-core-workflow.md
@@ -209,9 +209,12 @@ worth naming what each function answers:
   and biased toward high-cardinality features.
 - `mda_importance` — out-of-sample, by permutation. Takes
   `event_end_indices` (plus `n_splits`, `pct_embargo`) and builds *purged*
-  splits from them. This is the one to trust when the two disagree — but
-  only if you actually pass `event_end_indices`; the default builds
-  degenerate one-row intervals and purges nothing.
+  splits from them. This is the one to trust when the two disagree.
+  `event_end_indices` is **required**: omitting it raises, because a
+  missing horizon used to yield degenerate one-row intervals that purged
+  nothing. To accept embargo-only splits, opt out explicitly with
+  `allow_unpurged=True` — the result then reports
+  `cv["method"] == "kfold_embargo_only"` and `cv["purged"] is False`.
 - `sfi_importance` — one feature at a time, so it is the only one immune
   to the substitution effect. Also purged; also slow, since it refits per
   feature.

--- a/docs-site/src/data/moduleDocs.ts
+++ b/docs-site/src/data/moduleDocs.ts
@@ -1695,9 +1695,22 @@ X = [[0.1, 0.5, 0.3], [0.2, 0.4, 0.1], ...]  # n_samples × n_features
 y = [1.0, 0.0, 1.0, ...]  # binary labels
 names = ["momentum", "volatility", "spread"]
 
+# event_end_indices[i] is the row at which sample i's label resolves. It is
+# REQUIRED for the purged methods: without it every sample would be a
+# degenerate one-row interval, nothing would be purged, and the training
+# folds would leak label information from the test fold. Passing it is what
+# makes the split actually purged.
+ends = [i + 3 for i in range(len(y))]
+
 mdi = mdi_importance(X, y, feature_names=names, n_estimators=32)
-mda = mda_importance(X, y, feature_names=names, n_splits=5, pct_embargo=0.01)
-sfi = sfi_importance(X, y, feature_names=names, n_splits=5)
+mda = mda_importance(X, y, feature_names=names, event_end_indices=ends,
+                     n_splits=5, pct_embargo=0.01)
+sfi = sfi_importance(X, y, feature_names=names, event_end_indices=ends,
+                     n_splits=5)
+
+# mda["cv"]["purged"] is True here. It is False -- and "method" reads
+# "kfold_embargo_only" -- if you deliberately opt out with
+# allow_unpurged=True, so an unpurged run can never look like a purged one.
 
 # Each returns: {"table": pl.DataFrame, "viz_payload": {...}, ...}
 print(mdi["table"])  # feature | mean | std | stderr

--- a/docs/python_bindings.md
+++ b/docs/python_bindings.md
@@ -182,7 +182,7 @@ Input conventions:
 - `feature_screen_report(...)`
 
 Default behavior:
-- Purged K-Fold + embargo defaults for MDA/SFI (`n_splits=5`, `pct_embargo=0.01`)
+- Purged K-Fold + embargo for MDA/SFI (`n_splits=5`, `pct_embargo=0.01`). `event_end_indices` is required — omitting it raises rather than silently returning unpurged results; pass `allow_unpurged=True` to accept embargo-only splits explicitly.
 - configurable scoring: `neg_log_loss`, `accuracy`, `f1`
 - notebook-ready outputs: polars tables + viz payload dictionaries
 

--- a/python/openquant/feature_diagnostics.py
+++ b/python/openquant/feature_diagnostics.py
@@ -59,8 +59,22 @@ def _sample_weight(weights: Sequence[float] | None, n_rows: int) -> list[float] 
     return out
 
 
-def _build_intervals(event_end_indices: Sequence[int] | None, n_rows: int) -> list[tuple[int, int]]:
+def _build_intervals(
+    event_end_indices: Sequence[int] | None,
+    n_rows: int,
+    allow_unpurged: bool = False,
+) -> list[tuple[int, int]]:
     if event_end_indices is None:
+        if not allow_unpurged:
+            raise ValueError(
+                "event_end_indices is required for purged cross-validation. Without "
+                "label end indices every sample becomes a degenerate one-row interval "
+                "(i, i), which can only overlap the test rows themselves, so the purge "
+                "step removes nothing and training folds leak label information from "
+                "the test fold. Pass event_end_indices (the row index at which each "
+                "sample's label is resolved), or pass allow_unpurged=True to accept "
+                "embargo-only splits explicitly."
+            )
         return [(i, i) for i in range(n_rows)]
     ends = [int(v) for v in event_end_indices]
     if len(ends) != n_rows:
@@ -348,12 +362,13 @@ def mda_importance(
     n_splits: int = 5,
     pct_embargo: float = 0.01,
     scoring: str = "neg_log_loss",
+    allow_unpurged: bool = False,
 ) -> dict[str, object]:
     x = _as_matrix(X)
     yv = _as_vector(y, len(x))
     names = _feature_names(len(x[0]), feature_names)
     weights = _sample_weight(sample_weight, len(x))
-    intervals = _build_intervals(event_end_indices, len(x))
+    intervals = _build_intervals(event_end_indices, len(x), allow_unpurged=allow_unpurged)
     splits = _purged_kfold_splits(intervals, n_splits=n_splits, pct_embargo=pct_embargo)
 
     per_feature: list[list[float]] = [[] for _ in names]
@@ -392,7 +407,8 @@ def mda_importance(
         "records": table.to_dicts(),
         "viz_payload": payload,
         "cv": {
-            "method": "purged_kfold",
+            "method": "purged_kfold" if event_end_indices is not None else "kfold_embargo_only",
+            "purged": event_end_indices is not None,
             "n_splits": n_splits,
             "pct_embargo": pct_embargo,
             "fold_count": len(splits),
@@ -411,12 +427,13 @@ def sfi_importance(
     n_splits: int = 5,
     pct_embargo: float = 0.01,
     scoring: str = "neg_log_loss",
+    allow_unpurged: bool = False,
 ) -> dict[str, object]:
     x = _as_matrix(X)
     yv = _as_vector(y, len(x))
     names = _feature_names(len(x[0]), feature_names)
     weights = _sample_weight(sample_weight, len(x))
-    intervals = _build_intervals(event_end_indices, len(x))
+    intervals = _build_intervals(event_end_indices, len(x), allow_unpurged=allow_unpurged)
     splits = _purged_kfold_splits(intervals, n_splits=n_splits, pct_embargo=pct_embargo)
 
     per_feature: list[list[float]] = [[] for _ in names]
@@ -445,7 +462,8 @@ def sfi_importance(
         "records": table.to_dicts(),
         "viz_payload": payload,
         "cv": {
-            "method": "purged_kfold",
+            "method": "purged_kfold" if event_end_indices is not None else "kfold_embargo_only",
+            "purged": event_end_indices is not None,
             "n_splits": n_splits,
             "pct_embargo": pct_embargo,
             "fold_count": len(splits),
@@ -587,12 +605,13 @@ def substitution_effect_report(
     scoring: str = "neg_log_loss",
     corr_threshold: float = 0.9,
     orthogonalize: bool = True,
+    allow_unpurged: bool = False,
 ) -> dict[str, object]:
     x = _as_matrix(X)
     yv = _as_vector(y, len(x))
     names = _feature_names(len(x[0]), feature_names)
     weights = _sample_weight(sample_weight, len(x))
-    intervals = _build_intervals(event_end_indices, len(x))
+    intervals = _build_intervals(event_end_indices, len(x), allow_unpurged=allow_unpurged)
     splits = _purged_kfold_splits(intervals, n_splits=n_splits, pct_embargo=pct_embargo)
 
     mda = mda_importance(
@@ -604,6 +623,7 @@ def substitution_effect_report(
         n_splits=n_splits,
         pct_embargo=pct_embargo,
         scoring=scoring,
+        allow_unpurged=allow_unpurged,
     )
     base_table: pl.DataFrame = mda["table"]
     base_map = {row["feature"]: float(row["mean"]) for row in base_table.to_dicts()}
@@ -683,6 +703,7 @@ def substitution_effect_report(
             n_splits=n_splits,
             pct_embargo=pct_embargo,
             scoring=scoring,
+            allow_unpurged=allow_unpurged,
         )
         corr_abs_max = _max_abs_offdiag(corr)
         ortho_corr = _corr_matrix(x_ortho)

--- a/python/tests/test_feature_diagnostics_purging.py
+++ b/python/tests/test_feature_diagnostics_purging.py
@@ -1,0 +1,82 @@
+"""Regression tests for purged-CV leakage in feature_diagnostics.
+
+The default ``event_end_indices=None`` used to build degenerate one-row
+label intervals ``(i, i)``, which can only overlap the test rows themselves.
+Purging therefore removed zero *extra* rows and the returned ``cv`` block
+still claimed ``method == "purged_kfold"`` -- silent leakage.
+"""
+
+import random
+
+import pytest
+
+import openquant
+from openquant.feature_diagnostics import _build_intervals, _purged_kfold_splits
+
+
+def _dataset(n: int = 120):
+    rng = random.Random(7)
+    x = []
+    y = []
+    for i in range(n):
+        f0 = rng.gauss(0.0, 1.0)
+        f1 = rng.gauss(0.0, 1.0)
+        score = 0.8 * f0 + 0.3 * rng.gauss(0.0, 1.0)
+        x.append([f0, f1])
+        y.append(1.0 if score > 0 else 0.0)
+    return x, y, ["f0", "f1"]
+
+
+def test_purging_removes_rows_whose_labels_overlap_the_test_fold():
+    """With real label spans, purging must drop train rows -- and the
+    degenerate one-row intervals must be shown to drop none."""
+    n = 100
+    horizon = 10
+    spans = [min(n - 1, i + horizon) for i in range(n)]
+
+    purged = _purged_kfold_splits(
+        _build_intervals(spans, n),
+        n_splits=5,
+        pct_embargo=0.0,
+    )
+    degenerate = _purged_kfold_splits(
+        [(i, i) for i in range(n)],
+        n_splits=5,
+        pct_embargo=0.0,
+    )
+
+    # Fold 1 tests rows 20..39; rows 10..19 carry labels ending at 20..29.
+    train_purged, test_idx = purged[1]
+    train_degenerate, _ = degenerate[1]
+    assert test_idx[0] == 20 and test_idx[-1] == 39
+
+    leaked = [i for i in range(10, 20)]
+    assert all(i in train_degenerate for i in leaked), "degenerate intervals purge nothing"
+    assert not any(i in train_purged for i in leaked), "purging must drop overlapping rows"
+    assert len(train_purged) < len(train_degenerate)
+
+
+@pytest.mark.parametrize(
+    "fn",
+    ["mda_importance", "sfi_importance", "substitution_effect_report"],
+)
+def test_missing_label_spans_raises_instead_of_silently_not_purging(fn):
+    x, y, names = _dataset()
+    with pytest.raises(ValueError, match="event_end_indices"):
+        getattr(openquant.feature_diagnostics, fn)(x, y, feature_names=names)
+
+
+def test_explicit_opt_out_is_reported_as_unpurged():
+    x, y, names = _dataset()
+    out = openquant.feature_diagnostics.mda_importance(
+        x, y, feature_names=names, allow_unpurged=True
+    )
+    assert out["cv"]["purged"] is False
+    assert out["cv"]["method"] == "kfold_embargo_only"
+
+    spans = [min(len(x) - 1, i + 5) for i in range(len(x))]
+    purged_out = openquant.feature_diagnostics.mda_importance(
+        x, y, feature_names=names, event_end_indices=spans
+    )
+    assert purged_out["cv"]["purged"] is True
+    assert purged_out["cv"]["method"] == "purged_kfold"


### PR DESCRIPTION
**⚠️ BREAKING, and deliberately so** — calls omitting `event_end_indices` now raise instead of
returning leaked results. Fixed on the owner's instruction.

## The bug

`mda_importance(..., event_end_indices=None)` **purged nothing**.

`_build_intervals(None, n)` produced `(i, i)` for every sample, so `_overlaps` collapsed to `i == t`
and the purge loop only ever removed rows that were *already* in the test fold.

Measured, not theorised — n=100, 5 folds, embargo=0:

| | Training rows kept in fold 1 |
|---|---|
| Default (`event_end_indices=None`) | **80 of 80** — zero purged |
| Real label spans | 60 |

So anyone calling it with defaults got **silent leakage from the exact routine meant to prevent it**,
and their results looked better than they were.

Found by an agent verifying the Python workflow by actually running it — not by reading it.

## The fix

Raise unless the caller either passes spans or opts out explicitly with `allow_unpurged=True`.

The alternative — inventing a default horizon — was rejected on the grounds that it swaps silent
leakage for silent fabrication. Better to make the caller state their intent.

The result now reports `cv["method"]` (`purged_kfold` vs `kfold_embargo_only`) and `cv["purged"]`,
so an opt-out **cannot masquerade as purging**.

The error message explains the mechanism and the remedy rather than just failing.

## Two sibling routines had the identical bug

`sfi_importance` and `substitution_effect_report` — same shape, both fixed. The Rust `PurgedKFold`
and `hyperparameter_tuning` already require `samples_info_sets` and were never affected.

## Verification

- **Regression test written first and proven to fail** against the pre-fix code: 4 failed
  (3 × `DID NOT RAISE`), 5 passed after the fix
- Full suite: **37 passed** · `cargo fmt --check` 0 · zero Rust changed
- Docs gates after the doc updates: `astro build` 0 · `check-content-schema` 0 · `check-links` 0 ·
  `check:api-drift` 0

No existing test broke — because nothing was asserting the leaked behaviour.

## Docs updated in the same PR

Four documented call sites would have started raising. They now pass `event_end_indices` and explain
why it is required. `workflows/python-core-workflow.md` had honestly *documented the bug*; it now
documents the fix.

**Nothing automated caught that** — `check:examples` compiles Rust blocks only. A Python equivalent
is tracked separately, and this PR is the argument for it.