### PR TITLE
build: bump ethnum 1.5.2 -> 1.5.3 so the crate compiles on stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "fallible-streaming-iterator"


### PR DESCRIPTION
**This is why three CI jobs are red, and it is not this project's code.**

`ethnum 1.5.2` does not compile on current stable rustc:

```
error[E0512]: cannot transmute between types of different sizes
  --> ethnum-1.5.2/src/error.rs:16:14
     note: target type: `TryFromIntError` (8 bits)
```

It arrives transitively via `polars-error`; nothing in this repo depends on it directly. Because the
failure is in the *build*, it took down every cargo-dependent job at once — `lint-test`,
`py-bindings-smoke` and the notebooks/examples `smoke` test, plus the maturin wheel build underneath
the last two.

The last green run of those jobs was `5847972`, months ago. This is toolchain drift catching up with
a pinned dependency, not a regression from recent work — worth stating plainly, because the failures
first *appeared* on recent merges and look like they were caused by them.

## Change

One line in `Cargo.lock`: `ethnum 1.5.2` → `1.5.3`. No manifest change, nothing else moved
(`cargo update -p ethnum` locked exactly one package).

## Verification

- `cargo check --all-targets --all-features` → **exit 0**, zero build errors, no `ethnum` diagnostics
- Confirmed the E0512 is gone rather than merely hidden

## What this does *not* fix

`lint-test` will still fail, but for a different and now-visible reason: with the build no longer
dying at `ethnum`, clippy reaches this project's own code and reports **76 `-D warnings` errors**,
40 of them in `crates/openquant/src/microstructural_features.rs`. Those were always there; nothing
could see them because compilation stopped earlier.

That cleanup is tracked separately — it is a real piece of work, not a one-liner, and does not belong
in a dependency bump. **`py-bindings-smoke` and `smoke` should both go green with this change alone**,
since they build rather than lint.